### PR TITLE
Improvements to WasmVm

### DIFF
--- a/crates/vm/wasm/src/environment.rs
+++ b/crates/vm/wasm/src/environment.rs
@@ -99,14 +99,11 @@ impl Environment {
         Ok(())
     }
 
-    pub fn get_wasmer_memory<'a>(
-        &self,
-        wasm_store: &'a impl AsStoreRef,
-    ) -> VmResult<MemoryView<'a>> {
+    pub fn get_wasmer_memory<'a>(&self, store: &'a impl AsStoreRef) -> VmResult<MemoryView<'a>> {
         self.wasmer_memory
             .as_ref()
             .ok_or(VmError::WasmerMemoryNotSet)
-            .map(|mem| mem.view(wasm_store))
+            .map(|mem| mem.view(store))
     }
 
     pub fn get_wasmer_instance(&self) -> VmResult<&Instance> {
@@ -116,11 +113,11 @@ impl Environment {
 
     pub fn call_function1(
         &self,
-        wasm_store: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         name: &str,
         args: &[Value],
     ) -> VmResult<Value> {
-        let ret = self.call_function(wasm_store, name, args)?;
+        let ret = self.call_function(store, name, args)?;
         if ret.len() != 1 {
             return Err(VmError::ReturnCount {
                 name: name.into(),
@@ -133,11 +130,11 @@ impl Environment {
 
     pub fn call_function0(
         &self,
-        wasm_store: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         name: &str,
         args: &[Value],
     ) -> VmResult<()> {
-        let ret = self.call_function(wasm_store, name, args)?;
+        let ret = self.call_function(store, name, args)?;
         if ret.len() != 0 {
             return Err(VmError::ReturnCount {
                 name: name.into(),
@@ -150,14 +147,14 @@ impl Environment {
 
     fn call_function(
         &self,
-        wasm_store: &mut impl AsStoreMut,
+        store: &mut impl AsStoreMut,
         name: &str,
         args: &[Value],
     ) -> VmResult<Box<[Value]>> {
         self.get_wasmer_instance()?
             .exports
             .get_function(name)?
-            .call(wasm_store, args)
+            .call(store, args)
             .map_err(Into::into)
     }
 }

--- a/crates/vm/wasm/src/environment.rs
+++ b/crates/vm/wasm/src/environment.rs
@@ -30,12 +30,11 @@ pub struct Environment {
     wasmer_instance: Option<NonNull<Instance>>,
 }
 
-// Wasmer instance isn't Send/Sync. We manually mark it to be.
-// cosmwasm_vm does the same:
+// The Wasmer instance isn't `Send`. We manually mark it as is.
+// cosmwasm-vm does the same:
 // https://github.com/CosmWasm/cosmwasm/blob/v2.0.3/packages/vm/src/environment.rs#L120-L122
 // TODO: need to think about whether this is safe
 unsafe impl Send for Environment {}
-unsafe impl Sync for Environment {}
 
 impl Environment {
     pub fn new(

--- a/crates/vm/wasm/src/environment.rs
+++ b/crates/vm/wasm/src/environment.rs
@@ -13,8 +13,8 @@ pub struct Environment {
     pub gas_tracker: GasTracker,
     iterators: HashMap<i32, Iterator>,
     next_iterator_id: i32,
-    /// Memory of the Wasmer instance. Necessary to read data from or write data
-    /// to the memory.
+    /// Memory of the Wasmer instance. Necessary for reading data from or
+    /// writing data to the memory.
     ///
     /// Optional because during the flow of creating the Wasmer instance, the
     /// `Environment` needs to be created before the instance, which the memory

--- a/crates/vm/wasm/src/environment.rs
+++ b/crates/vm/wasm/src/environment.rs
@@ -79,13 +79,24 @@ impl Environment {
     }
 
     pub fn set_wasmer_memory(&mut self, instance: &Instance) -> VmResult<()> {
+        if self.wasmer_memory.is_some() {
+            return Err(VmError::WasmerMemoryAlreadySet);
+        }
+
         let memory = instance.exports.get_memory("memory")?;
         self.wasmer_memory = Some(memory.clone());
+
         Ok(())
     }
 
-    pub fn set_wasmer_instance(&mut self, instance: &Instance) {
+    pub fn set_wasmer_instance(&mut self, instance: &Instance) -> VmResult<()> {
+        if self.wasmer_instance.is_some() {
+            return Err(VmError::WasmerInstanceAlreadySet);
+        }
+
         self.wasmer_instance = Some(NonNull::from(instance));
+
+        Ok(())
     }
 
     pub fn get_wasmer_memory<'a>(
@@ -94,7 +105,7 @@ impl Environment {
     ) -> VmResult<MemoryView<'a>> {
         self.wasmer_memory
             .as_ref()
-            .ok_or(VmError::MemoryNotSet)
+            .ok_or(VmError::WasmerMemoryNotSet)
             .map(|mem| mem.view(wasm_store))
     }
 

--- a/crates/vm/wasm/src/error.rs
+++ b/crates/vm/wasm/src/error.rs
@@ -36,20 +36,17 @@ pub enum VmError {
     #[error("failed to instantiate Wasm module: {0}")]
     Instantiation(String),
 
-    #[error("failed to read lock ContextData")]
-    FailedReadLock,
+    #[error("Wasmer memory not set in Environment")]
+    WasmerMemoryNotSet,
 
-    #[error("failed to write lock ContextData")]
-    FailedWriteLock,
+    #[error("Wasmer memory already set in Environment")]
+    WasmerMemoryAlreadySet,
 
-    #[error("memory is not set in Environment")]
-    MemoryNotSet,
-
-    #[error("store is not set in ContextData")]
-    StoreNotSet,
-
-    #[error("wasmer instance is not set in ContextData")]
+    #[error("Wasmer instance not set in ContextData")]
     WasmerInstanceNotSet,
+
+    #[error("Wasmer instance already set in ContextData")]
+    WasmerInstanceAlreadySet,
 
     #[error("iterator with ID `{iterator_id}` not found")]
     IteratorNotFound { iterator_id: i32 },

--- a/crates/vm/wasm/src/imports.rs
+++ b/crates/vm/wasm/src/imports.rs
@@ -8,16 +8,16 @@ use {
 };
 
 pub fn db_read(mut fe: FunctionEnvMut<Environment>, key_ptr: u32) -> VmResult<u32> {
-    let (env, mut wasm_store) = fe.data_and_store_mut();
+    let (env, mut store) = fe.data_and_store_mut();
 
-    let key = read_from_memory(env, &wasm_store, key_ptr)?;
+    let key = read_from_memory(env, &store, key_ptr)?;
 
     // If the record doesn't exist, return a zero pointer.
     let Some(value) = env.storage.read(&key) else {
         return Ok(0);
     };
 
-    write_to_memory(env, &mut wasm_store, &value)
+    write_to_memory(env, &mut store, &value)
 }
 
 pub fn db_scan(
@@ -26,16 +26,16 @@ pub fn db_scan(
     max_ptr: u32,
     order: i32,
 ) -> VmResult<i32> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
     // Parse iteration parameters provided by the module and create iterator.
     let min = if min_ptr != 0 {
-        Some(read_from_memory(env, &wasm_store, min_ptr)?)
+        Some(read_from_memory(env, &store, min_ptr)?)
     } else {
         None
     };
     let max = if max_ptr != 0 {
-        Some(read_from_memory(env, &wasm_store, max_ptr)?)
+        Some(read_from_memory(env, &store, max_ptr)?)
     } else {
         None
     };
@@ -46,43 +46,43 @@ pub fn db_scan(
 }
 
 pub fn db_next(mut fe: FunctionEnvMut<Environment>, iterator_id: i32) -> VmResult<u32> {
-    let (env, mut wasm_store) = fe.data_and_store_mut();
+    let (env, mut store) = fe.data_and_store_mut();
 
     // If the iterator has reached its end, return a zero pointer.
     let Some(record) = env.advance_iterator(iterator_id)? else {
         return Ok(0);
     };
 
-    write_to_memory(env, &mut wasm_store, &encode_record(record))
+    write_to_memory(env, &mut store, &encode_record(record))
 }
 
 pub fn db_next_key(mut fe: FunctionEnvMut<Environment>, iterator_id: i32) -> VmResult<u32> {
-    let (env, mut wasm_store) = fe.data_and_store_mut();
+    let (env, mut store) = fe.data_and_store_mut();
 
     // If the iterator has reached its end, return a zero pointer.
     let Some((key, _)) = env.advance_iterator(iterator_id)? else {
         return Ok(0);
     };
 
-    write_to_memory(env, &mut wasm_store, &key)
+    write_to_memory(env, &mut store, &key)
 }
 
 pub fn db_next_value(mut fe: FunctionEnvMut<Environment>, iterator_id: i32) -> VmResult<u32> {
-    let (env, mut wasm_store) = fe.data_and_store_mut();
+    let (env, mut store) = fe.data_and_store_mut();
 
     // If the iterator has reached its end, return a zero pointer.
     let Some((_, value)) = env.advance_iterator(iterator_id)? else {
         return Ok(0);
     };
 
-    write_to_memory(env, &mut wasm_store, &value)
+    write_to_memory(env, &mut store, &value)
 }
 
 pub fn db_write(mut fe: FunctionEnvMut<Environment>, key_ptr: u32, value_ptr: u32) -> VmResult<()> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
-    let key = read_from_memory(env, &wasm_store, key_ptr)?;
-    let value = read_from_memory(env, &wasm_store, value_ptr)?;
+    let key = read_from_memory(env, &store, key_ptr)?;
+    let value = read_from_memory(env, &store, value_ptr)?;
 
     env.storage.write(&key, &value);
 
@@ -90,9 +90,9 @@ pub fn db_write(mut fe: FunctionEnvMut<Environment>, key_ptr: u32, value_ptr: u3
 }
 
 pub fn db_remove(mut fe: FunctionEnvMut<Environment>, key_ptr: u32) -> VmResult<()> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
-    let key = read_from_memory(env, &wasm_store, key_ptr)?;
+    let key = read_from_memory(env, &store, key_ptr)?;
 
     env.storage.remove(&key);
 
@@ -104,15 +104,15 @@ pub fn db_remove_range(
     min_ptr: u32,
     max_ptr: u32,
 ) -> VmResult<()> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
     let min = if min_ptr != 0 {
-        Some(read_from_memory(env, &wasm_store, min_ptr)?)
+        Some(read_from_memory(env, &store, min_ptr)?)
     } else {
         None
     };
     let max = if max_ptr != 0 {
-        Some(read_from_memory(env, &wasm_store, max_ptr)?)
+        Some(read_from_memory(env, &store, max_ptr)?)
     } else {
         None
     };
@@ -123,11 +123,11 @@ pub fn db_remove_range(
 }
 
 pub fn debug(mut fe: FunctionEnvMut<Environment>, addr_ptr: u32, msg_ptr: u32) -> VmResult<()> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
-    let addr_bytes = read_from_memory(env, &wasm_store, addr_ptr)?;
+    let addr_bytes = read_from_memory(env, &store, addr_ptr)?;
     let addr = Addr::try_from(addr_bytes)?;
-    let msg_bytes = read_from_memory(env, &wasm_store, msg_ptr)?;
+    let msg_bytes = read_from_memory(env, &store, msg_ptr)?;
     let msg = String::from_utf8(msg_bytes)?;
 
     info!(
@@ -139,15 +139,15 @@ pub fn debug(mut fe: FunctionEnvMut<Environment>, addr_ptr: u32, msg_ptr: u32) -
 }
 
 pub fn query_chain(mut fe: FunctionEnvMut<Environment>, req_ptr: u32) -> VmResult<u32> {
-    let (env, mut wasm_store) = fe.data_and_store_mut();
+    let (env, mut store) = fe.data_and_store_mut();
 
-    let req_bytes = read_from_memory(env, &wasm_store, req_ptr)?;
+    let req_bytes = read_from_memory(env, &store, req_ptr)?;
     let req: QueryRequest = from_json_slice(req_bytes)?;
 
     let res = env.querier.query_chain(req)?;
     let res_bytes = to_json_vec(&res)?;
 
-    write_to_memory(env, &mut wasm_store, &res_bytes)
+    write_to_memory(env, &mut store, &res_bytes)
 }
 
 pub fn secp256k1_verify(
@@ -156,11 +156,11 @@ pub fn secp256k1_verify(
     sig_ptr: u32,
     pk_ptr: u32,
 ) -> VmResult<i32> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
-    let msg_hash = read_from_memory(env, &wasm_store, msg_hash_ptr)?;
-    let sig = read_from_memory(env, &wasm_store, sig_ptr)?;
-    let pk = read_from_memory(env, &wasm_store, pk_ptr)?;
+    let msg_hash = read_from_memory(env, &store, msg_hash_ptr)?;
+    let sig = read_from_memory(env, &store, sig_ptr)?;
+    let pk = read_from_memory(env, &store, pk_ptr)?;
 
     match grug_crypto::secp256k1_verify(&msg_hash, &sig, &pk) {
         Ok(()) => Ok(0),
@@ -174,11 +174,11 @@ pub fn secp256r1_verify(
     sig_ptr: u32,
     pk_ptr: u32,
 ) -> VmResult<i32> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
-    let msg_hash = read_from_memory(env, &wasm_store, msg_hash_ptr)?;
-    let sig = read_from_memory(env, &wasm_store, sig_ptr)?;
-    let pk = read_from_memory(env, &wasm_store, pk_ptr)?;
+    let msg_hash = read_from_memory(env, &store, msg_hash_ptr)?;
+    let sig = read_from_memory(env, &store, sig_ptr)?;
+    let pk = read_from_memory(env, &store, pk_ptr)?;
 
     match grug_crypto::secp256r1_verify(&msg_hash, &sig, &pk) {
         Ok(()) => Ok(0),
@@ -193,10 +193,10 @@ pub fn secp256k1_pubkey_recover(
     recovery_id: u8,
     compressed: u8,
 ) -> VmResult<u32> {
-    let (env, mut wasm_store) = fe.data_and_store_mut();
+    let (env, mut store) = fe.data_and_store_mut();
 
-    let msg_hash = read_from_memory(env, &wasm_store, msg_hash_ptr)?;
-    let sig = read_from_memory(env, &wasm_store, sig_ptr)?;
+    let msg_hash = read_from_memory(env, &store, msg_hash_ptr)?;
+    let sig = read_from_memory(env, &store, sig_ptr)?;
 
     let compressed = match compressed {
         0 => false,
@@ -205,7 +205,7 @@ pub fn secp256k1_pubkey_recover(
     };
 
     match grug_crypto::secp256k1_pubkey_recover(&msg_hash, &sig, recovery_id, compressed) {
-        Ok(pk) => write_to_memory(env, &mut wasm_store, &pk),
+        Ok(pk) => write_to_memory(env, &mut store, &pk),
         Err(_) => Ok(0),
     }
 }
@@ -216,11 +216,11 @@ pub fn ed25519_verify(
     sig_ptr: u32,
     pk_ptr: u32,
 ) -> VmResult<i32> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
-    let msg_hash = read_from_memory(env, &wasm_store, msg_hash_ptr)?;
-    let sig = read_from_memory(env, &wasm_store, sig_ptr)?;
-    let pk = read_from_memory(env, &wasm_store, pk_ptr)?;
+    let msg_hash = read_from_memory(env, &store, msg_hash_ptr)?;
+    let sig = read_from_memory(env, &store, sig_ptr)?;
+    let pk = read_from_memory(env, &store, pk_ptr)?;
 
     match grug_crypto::ed25519_verify(&msg_hash, &sig, &pk) {
         Ok(()) => Ok(0),
@@ -234,11 +234,11 @@ pub fn ed25519_batch_verify(
     sigs_ptr: u32,
     pks_ptr: u32,
 ) -> VmResult<i32> {
-    let (env, wasm_store) = fe.data_and_store_mut();
+    let (env, store) = fe.data_and_store_mut();
 
-    let msgs_hash = read_from_memory(env, &wasm_store, msgs_hash_ptr)?;
-    let sigs = read_from_memory(env, &wasm_store, sigs_ptr)?;
-    let pks = read_from_memory(env, &wasm_store, pks_ptr)?;
+    let msgs_hash = read_from_memory(env, &store, msgs_hash_ptr)?;
+    let sigs = read_from_memory(env, &store, sigs_ptr)?;
+    let pks = read_from_memory(env, &store, pks_ptr)?;
 
     let msgs_hash = decode_sections(&msgs_hash);
     let sigs = decode_sections(&sigs);
@@ -253,12 +253,12 @@ pub fn ed25519_batch_verify(
 macro_rules! impl_hash_method {
     ($name:ident) => {
         pub fn $name(mut fe: FunctionEnvMut<Environment>, data_ptr: u32) -> VmResult<u32> {
-            let (env, mut wasm_store) = fe.data_and_store_mut();
+            let (env, mut store) = fe.data_and_store_mut();
 
-            let data = read_from_memory(env, &wasm_store, data_ptr)?;
+            let data = read_from_memory(env, &store, data_ptr)?;
             let hash = grug_crypto::$name(&data);
 
-            write_to_memory(env, &mut wasm_store, &hash)
+            write_to_memory(env, &mut store, &hash)
         }
     };
 }

--- a/crates/vm/wasm/src/memory.rs
+++ b/crates/vm/wasm/src/memory.rs
@@ -9,7 +9,7 @@ pub fn read_from_memory(
     wasm_store: &impl AsStoreRef,
     region_ptr: u32,
 ) -> VmResult<Vec<u8>> {
-    let memory = env.memory(&wasm_store)?;
+    let memory = env.get_wasmer_memory(&wasm_store)?;
 
     // read region
     let region = read_region(&memory, region_ptr)?;
@@ -41,7 +41,7 @@ pub fn write_to_memory(
         .call_function1(wasm_store, "allocate", &[(data.len() as u32).into()])?
         .try_into()
         .map_err(VmError::ReturnType)?;
-    let memory = env.memory(&wasm_store)?;
+    let memory = env.get_wasmer_memory(&wasm_store)?;
     let mut region = read_region(&memory, region_ptr)?;
     // don't forget to update region length
     region.length = data.len() as u32;

--- a/crates/vm/wasm/src/vm.rs
+++ b/crates/vm/wasm/src/vm.rs
@@ -108,7 +108,7 @@ impl Vm for WasmVm {
         // set memory/store/instance in the env
         let env = fe.as_mut(&mut store);
         env.set_memory(&instance)?;
-        env.set_wasm_instance(instance.as_ref())?;
+        env.set_wasm_instance(instance.as_ref());
 
         Ok(WasmInstance {
             instance,

--- a/crates/vm/wasm/src/vm.rs
+++ b/crates/vm/wasm/src/vm.rs
@@ -108,7 +108,7 @@ impl Vm for WasmVm {
         // set memory/store/instance in the env
         let env = fe.as_mut(&mut store);
         env.set_wasmer_memory(&instance)?;
-        env.set_wasmer_instance(instance.as_ref());
+        env.set_wasmer_instance(instance.as_ref())?;
 
         Ok(WasmInstance {
             instance,

--- a/crates/vm/wasm/src/vm.rs
+++ b/crates/vm/wasm/src/vm.rs
@@ -155,15 +155,15 @@ impl Instance for WasmInstance {
 
     fn call_in_0_out_1(mut self, name: &str, ctx: &Context) -> VmResult<Vec<u8>> {
         let mut fe_mut = self.fe.clone().into_mut(&mut self.store);
-        let (env, mut wasm_store) = fe_mut.data_and_store_mut();
+        let (env, mut store) = fe_mut.data_and_store_mut();
 
-        let ctx_ptr = write_to_memory(env, &mut wasm_store, &to_borsh_vec(ctx)?)?;
+        let ctx_ptr = write_to_memory(env, &mut store, &to_borsh_vec(ctx)?)?;
         let res_ptr: u32 = env
-            .call_function1(&mut wasm_store, name, &[ctx_ptr.into()])?
+            .call_function1(&mut store, name, &[ctx_ptr.into()])?
             .try_into()
             .map_err(VmError::ReturnType)?;
 
-        let data = read_then_wipe(env, &mut wasm_store, res_ptr)?;
+        let data = read_then_wipe(env, &mut store, res_ptr)?;
 
         self.consume_gas()?;
 
@@ -175,16 +175,16 @@ impl Instance for WasmInstance {
         P: AsRef<[u8]>,
     {
         let mut fe_mut = self.fe.clone().into_mut(&mut self.store);
-        let (env, mut wasm_store) = fe_mut.data_and_store_mut();
+        let (env, mut store) = fe_mut.data_and_store_mut();
 
-        let ctx_ptr = write_to_memory(env, &mut wasm_store, &to_borsh_vec(ctx)?)?;
-        let param1_ptr = write_to_memory(env, &mut wasm_store, param.as_ref())?;
+        let ctx_ptr = write_to_memory(env, &mut store, &to_borsh_vec(ctx)?)?;
+        let param1_ptr = write_to_memory(env, &mut store, param.as_ref())?;
         let res_ptr: u32 = env
-            .call_function1(&mut wasm_store, name, &[ctx_ptr.into(), param1_ptr.into()])?
+            .call_function1(&mut store, name, &[ctx_ptr.into(), param1_ptr.into()])?
             .try_into()
             .map_err(VmError::ReturnType)?;
 
-        let data = read_then_wipe(env, &mut wasm_store, res_ptr)?;
+        let data = read_then_wipe(env, &mut store, res_ptr)?;
 
         self.consume_gas()?;
 
@@ -203,20 +203,20 @@ impl Instance for WasmInstance {
         P2: AsRef<[u8]>,
     {
         let mut fe_mut = self.fe.clone().into_mut(&mut self.store);
-        let (env, mut wasm_store) = fe_mut.data_and_store_mut();
+        let (env, mut store) = fe_mut.data_and_store_mut();
 
-        let ctx_ptr = write_to_memory(env, &mut wasm_store, &to_borsh_vec(ctx)?)?;
-        let param1_ptr = write_to_memory(env, &mut wasm_store, param1.as_ref())?;
-        let param2_ptr = write_to_memory(env, &mut wasm_store, param2.as_ref())?;
+        let ctx_ptr = write_to_memory(env, &mut store, &to_borsh_vec(ctx)?)?;
+        let param1_ptr = write_to_memory(env, &mut store, param1.as_ref())?;
+        let param2_ptr = write_to_memory(env, &mut store, param2.as_ref())?;
         let res_ptr: u32 = env
-            .call_function1(&mut wasm_store, name, &[
+            .call_function1(&mut store, name, &[
                 ctx_ptr.into(),
                 param1_ptr.into(),
                 param2_ptr.into(),
             ])?
             .try_into()
             .map_err(VmError::ReturnType)?;
-        let data = read_then_wipe(env, &mut wasm_store, res_ptr)?;
+        let data = read_then_wipe(env, &mut store, res_ptr)?;
 
         self.consume_gas()?;
 

--- a/crates/vm/wasm/src/vm.rs
+++ b/crates/vm/wasm/src/vm.rs
@@ -107,8 +107,8 @@ impl Vm for WasmVm {
 
         // set memory/store/instance in the env
         let env = fe.as_mut(&mut store);
-        env.set_memory(&instance)?;
-        env.set_wasm_instance(instance.as_ref());
+        env.set_wasmer_memory(&instance)?;
+        env.set_wasmer_instance(instance.as_ref());
 
         Ok(WasmInstance {
             instance,


### PR DESCRIPTION
- Merge `ContextData` and `Environment` into one struct:

  Old:

  ```rust
  struct ContextData {
      pub storage: StorageProvider,
      pub querier: QuerierProvider<WasmVm>,
      pub iterators: HashMap<i32, Iterator>,
      pub next_iterator_id: i32,
      pub gas_tracker: GasTracker,
      wasmer_instance: Option<NonNull<Instance>>,
  }

  struct Environment {
      memory: Option<Memory>,
      data: Arc<RwLock<ContextData>>,
  }
  ```

  New:

  ```rust
  struct Environment {
      pub storage: StorageProvider,
      pub querier: QuerierProvider<WasmVm>,
      pub gas_tracker: GasTracker,
      iterators: HashMap<i32, Iterator>,
      next_iterator_id: i32,
      wasmer_memory: Option<Memory>,
      wasmer_instance: Option<NonNull<Instance>>,
  }
  ```

- Some renamings
- Add some comments