### PR TITLE
Crypto fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
  "rand_core",
  "serde",
  "sha2 0.10.8",
+ "signature",
  "subtle",
  "zeroize",
 ]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories    = { workspace = true }
 blake2        = { workspace = true }
 blake3        = { workspace = true }
 digest        = { workspace = true }
-ed25519-dalek = { workspace = true, features = ["batch"] }
+ed25519-dalek = { workspace = true, features = ["batch", "digest"] }
 k256          = { workspace = true }
 p256          = { workspace = true }
 sha2          = { workspace = true }

--- a/crates/crypto/src/identity_digest.rs
+++ b/crates/crypto/src/identity_digest.rs
@@ -50,22 +50,6 @@ macro_rules! identity {
         }
 
         impl $name {
-            /// Convert from a byte slice of unknown length. Error if the length isn't
-            /// exactly 32 bytes.
-            /// To convert from a byte slice of fixed size of 32 bytes, use `from_bytes`.
-            pub fn from_slice(slice: &[u8]) -> CryptoResult<Self> {
-                if slice.len() != $len {
-                    return Err(CryptoError::IncorrectLength {
-                        expect: $len,
-                        actual: slice.len(),
-                    });
-                }
-
-                Ok(Self {
-                    bytes: *GenericArray::from_slice(slice),
-                })
-            }
-
             pub fn into_bytes(self) -> [u8; $len] {
                 self.bytes.into()
             }

--- a/crates/crypto/src/identity_digest.rs
+++ b/crates/crypto/src/identity_digest.rs
@@ -1,8 +1,11 @@
 use {
     crate::{CryptoError, CryptoResult},
     digest::{
-        consts::U32, generic_array::GenericArray, FixedOutput, HashMarker, OutputSizeUser, Update,
+        consts::{U32, U64},
+        generic_array::GenericArray,
+        FixedOutput, HashMarker, Output, OutputSizeUser, Update,
     },
+    std::ops::Deref,
 };
 
 /// Try cast a slice to a fixed length array. Error if the size is incorrect.
@@ -38,60 +41,76 @@ pub fn truncate<const S: usize>(data: &[u8]) -> CryptoResult<[u8; S]> {
 ///
 /// Adapted from:
 /// <https://github.com/CosmWasm/cosmwasm/blob/main/packages/crypto/src/identity_digest.rs>
-#[derive(Default, Clone)]
-pub struct Identity256 {
-    bytes: GenericArray<u8, U32>,
-}
-
-impl Identity256 {
-    /// Convert from a byte slice of unknown length. Error if the length isn't
-    /// exactly 32 bytes.
-    /// To convert from a byte slice of fixed size of 32 bytes, use `from_bytes`.
-    pub fn from_slice(slice: &[u8]) -> CryptoResult<Self> {
-        if slice.len() != 32 {
-            return Err(CryptoError::IncorrectLength {
-                expect: 32,
-                actual: slice.len(),
-            });
+macro_rules! identity {
+    ($name:ident, $array_len:ty, $len:literal, $doc:literal) => {
+        #[derive(Default, Clone)]
+        #[doc = $doc]
+        pub struct $name {
+            bytes: GenericArray<u8, $array_len>,
         }
 
-        Ok(Self {
-            bytes: *GenericArray::from_slice(slice),
-        })
-    }
+        impl $name {
+            /// Convert from a byte slice of unknown length. Error if the length isn't
+            /// exactly 32 bytes.
+            /// To convert from a byte slice of fixed size of 32 bytes, use `from_bytes`.
+            pub fn from_slice(slice: &[u8]) -> CryptoResult<Self> {
+                if slice.len() != $len {
+                    return Err(CryptoError::IncorrectLength {
+                        expect: $len,
+                        actual: slice.len(),
+                    });
+                }
 
-    pub fn into_bytes(self) -> [u8; 32] {
-        self.bytes.into()
-    }
+                Ok(Self {
+                    bytes: *GenericArray::from_slice(slice),
+                })
+            }
 
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes
-    }
-}
+            pub fn into_bytes(self) -> [u8; $len] {
+                self.bytes.into()
+            }
 
-impl From<[u8; 32]> for Identity256 {
-    fn from(bytes: [u8; 32]) -> Self {
-        Self {
-            bytes: *GenericArray::from_slice(&bytes),
+            pub fn as_bytes(&self) -> &[u8] {
+                &self.bytes
+            }
         }
-    }
+
+        impl From<[u8; $len]> for $name {
+            fn from(bytes: [u8; $len]) -> Self {
+                Self {
+                    bytes: *GenericArray::from_slice(&bytes),
+                }
+            }
+        }
+
+        impl Deref for $name {
+            type Target = [u8];
+
+            fn deref(&self) -> &Self::Target {
+                &self.bytes
+            }
+        }
+
+        impl Update for $name {
+            fn update(&mut self, data: &[u8]) {
+                assert_eq!(data.len(), $len);
+                self.bytes = *GenericArray::from_slice(data);
+            }
+        }
+
+        impl FixedOutput for $name {
+            fn finalize_into(self, out: &mut Output<Self>) {
+                *out = self.bytes;
+            }
+        }
+
+        impl OutputSizeUser for $name {
+            type OutputSize = $array_len;
+        }
+
+        impl HashMarker for $name {}
+    };
 }
 
-impl OutputSizeUser for Identity256 {
-    type OutputSize = U32;
-}
-
-impl Update for Identity256 {
-    fn update(&mut self, data: &[u8]) {
-        assert_eq!(data.len(), 32);
-        self.bytes = *GenericArray::from_slice(data);
-    }
-}
-
-impl FixedOutput for Identity256 {
-    fn finalize_into(self, out: &mut digest::Output<Self>) {
-        *out = self.bytes
-    }
-}
-
-impl HashMarker for Identity256 {}
+identity!(Identity256, U32, 32, "A digest of 32 byte length");
+identity!(Identity512, U64, 64, "A digest of 64 byte length");

--- a/crates/crypto/src/secp256k1.rs
+++ b/crates/crypto/src/secp256k1.rs
@@ -88,31 +88,27 @@ mod tests {
         // generate a valid signature
         let sk = SigningKey::random(&mut OsRng);
         let vk = VerifyingKey::from(&sk);
-        let prehash_msg = b"Jake";
-        let msg = Identity256::from(sha2_256(prehash_msg));
-        let sig: Signature = sk.sign_digest(msg.clone());
+        let msg = b"Jake";
+        let msg_hash = Identity256::from(sha2_256(msg));
+        let sig: Signature = sk.sign_digest(msg_hash.clone());
 
         // valid signature
-        assert!(secp256k1_verify(msg.as_bytes(), &sig.to_bytes(), &vk.to_sec1_bytes()).is_ok());
+        assert!(secp256k1_verify(&msg_hash, &sig.to_bytes(), &vk.to_sec1_bytes()).is_ok());
 
         // incorrect private key
         let false_sk = SigningKey::random(&mut OsRng);
-        let false_sig: Signature = false_sk.sign_digest(msg.clone());
-        assert!(
-            secp256k1_verify(msg.as_bytes(), &false_sig.to_bytes(), &vk.to_sec1_bytes()).is_err()
-        );
+        let false_sig: Signature = false_sk.sign_digest(msg_hash.clone());
+        assert!(secp256k1_verify(&msg_hash, &false_sig.to_bytes(), &vk.to_sec1_bytes()).is_err());
 
         // incorrect public key
         let false_sk = SigningKey::random(&mut OsRng);
         let false_vk = VerifyingKey::from(&false_sk);
-        assert!(
-            secp256k1_verify(msg.as_bytes(), &sig.to_bytes(), &false_vk.to_sec1_bytes()).is_err()
-        );
+        assert!(secp256k1_verify(&msg_hash, &sig.to_bytes(), &false_vk.to_sec1_bytes()).is_err());
 
         // incorrect message
-        let false_prehash_msg = b"Larry";
-        let false_msg = sha2_256(false_prehash_msg);
-        assert!(secp256k1_verify(&false_msg, &sig.to_bytes(), &vk.to_sec1_bytes()).is_err());
+        let false_msg = b"Larry";
+        let false_msg_hash = sha2_256(false_msg);
+        assert!(secp256k1_verify(&false_msg_hash, &sig.to_bytes(), &vk.to_sec1_bytes()).is_err());
     }
 
     #[test]
@@ -120,26 +116,18 @@ mod tests {
         // generate a valid signature
         let sk = SigningKey::random(&mut OsRng);
         let vk = VerifyingKey::from(&sk);
-        let prehash_msg = b"Jake";
-        let msg = Identity256::from(sha2_256(prehash_msg));
-        let (sig, recovery_id) = sk.sign_digest_recoverable(msg.clone()).unwrap();
+        let msg = b"Jake";
+        let msg_hash = Identity256::from(sha2_256(msg));
+        let (sig, recovery_id) = sk.sign_digest_recoverable(msg_hash.clone()).unwrap();
 
-        let recovered_pk = secp256k1_pubkey_recover(
-            msg.as_bytes(),
-            sig.to_vec().as_slice(),
-            recovery_id.to_byte(),
-            true,
-        )
-        .unwrap();
+        let recovered_pk =
+            secp256k1_pubkey_recover(&msg_hash, &sig.to_vec(), recovery_id.to_byte(), true)
+                .unwrap();
         assert_eq!(recovered_pk, vk.to_encoded_point(true).as_bytes());
 
-        let recovered_pk = secp256k1_pubkey_recover(
-            msg.as_bytes(),
-            sig.to_vec().as_slice(),
-            recovery_id.to_byte(),
-            false,
-        )
-        .unwrap();
+        let recovered_pk =
+            secp256k1_pubkey_recover(&msg_hash, &sig.to_vec(), recovery_id.to_byte(), false)
+                .unwrap();
         assert_eq!(recovered_pk, vk.to_encoded_point(false).as_bytes());
     }
 }

--- a/crates/crypto/src/secp256k1.rs
+++ b/crates/crypto/src/secp256k1.rs
@@ -3,12 +3,14 @@ use {
     k256::ecdsa::{signature::DigestVerifier, RecoveryId, Signature, VerifyingKey},
 };
 
+const SECP256K1_DIGEST_LEN: usize = 32;
 const SECP256K1_PUBKEY_LENS: [usize; 2] = [33, 65]; // compressed, uncompressed
 const SECP256K1_SIGNATURE_LEN: usize = 64;
 
 /// NOTE: This function takes the hash of the message, not the prehash.
 pub fn secp256k1_verify(msg_hash: &[u8], sig: &[u8], pk: &[u8]) -> CryptoResult<()> {
-    let msg = Identity256::from_slice(msg_hash)?;
+    let msg_hash = to_sized::<SECP256K1_DIGEST_LEN>(msg_hash)?;
+    let msg_hash = Identity256::from(msg_hash);
 
     let sig = to_sized::<SECP256K1_SIGNATURE_LEN>(sig)?;
     let mut sig = Signature::from_bytes(&sig.into())?;
@@ -28,7 +30,7 @@ pub fn secp256k1_verify(msg_hash: &[u8], sig: &[u8], pk: &[u8]) -> CryptoResult<
     }
 
     VerifyingKey::from_sec1_bytes(pk)?
-        .verify_digest(msg, &sig)
+        .verify_digest(msg_hash, &sig)
         .map_err(Into::into)
 }
 
@@ -50,7 +52,8 @@ pub fn secp256k1_pubkey_recover(
     recovery_id: u8,
     compressed: bool,
 ) -> CryptoResult<Vec<u8>> {
-    let msg = Identity256::from_slice(msg_hash)?;
+    let msg_hash = to_sized::<SECP256K1_DIGEST_LEN>(msg_hash)?;
+    let msg_hash = Identity256::from(msg_hash);
 
     let sig = to_sized::<SECP256K1_SIGNATURE_LEN>(sig)?;
     let mut sig = Signature::from_bytes(&sig.into())?;
@@ -67,7 +70,7 @@ pub fn secp256k1_pubkey_recover(
     }
 
     // Convert the public key to SEC1 bytes
-    VerifyingKey::recover_from_digest(msg, &sig, id)
+    VerifyingKey::recover_from_digest(msg_hash, &sig, id)
         .map(|vk| vk.to_encoded_point(compressed).to_bytes().into())
         .map_err(Into::into)
 }

--- a/crates/crypto/src/secp256r1.rs
+++ b/crates/crypto/src/secp256r1.rs
@@ -3,12 +3,14 @@ use {
     p256::ecdsa::{signature::DigestVerifier, Signature, VerifyingKey},
 };
 
+const SECP256R1_DIGEST_LEN: usize = 32;
 const SECP256R1_PUBKEY_LENS: [usize; 2] = [33, 65]; // compressed, uncompressed
 const SECP256R1_SIGNATURE_LEN: usize = 64;
 
 /// NOTE: This function takes the hash of the message, not the prehash.
 pub fn secp256r1_verify(msg_hash: &[u8], sig: &[u8], pk: &[u8]) -> CryptoResult<()> {
-    let msg = Identity256::from_slice(msg_hash)?;
+    let msg_hash = to_sized::<SECP256R1_DIGEST_LEN>(msg_hash)?;
+    let msg_hash = Identity256::from(msg_hash);
 
     let sig = to_sized::<SECP256R1_SIGNATURE_LEN>(sig)?;
     let mut sig = Signature::from_bytes(&sig.into())?;
@@ -28,7 +30,7 @@ pub fn secp256r1_verify(msg_hash: &[u8], sig: &[u8], pk: &[u8]) -> CryptoResult<
     }
 
     VerifyingKey::from_sec1_bytes(pk)?
-        .verify_digest(msg, &sig)
+        .verify_digest(msg_hash, &sig)
         .map_err(Into::into)
 }
 

--- a/crates/crypto/src/secp256r1.rs
+++ b/crates/crypto/src/secp256r1.rs
@@ -48,35 +48,26 @@ mod tests {
         // generate a valid signature
         let sk = SigningKey::random(&mut OsRng);
         let vk = VerifyingKey::from(&sk);
-        let prehash_msg = b"Jake";
-        let msg = Identity256::from(sha2_256(prehash_msg));
-        let sig: Signature = sk.sign_digest(msg.clone());
+        let msg = b"Jake";
+        let msg_hash = Identity256::from(sha2_256(msg));
+        let sig: Signature = sk.sign_digest(msg_hash.clone());
 
         // valid signature
-        assert!(secp256r1_verify(msg.as_bytes(), &sig.to_bytes(), &vk.to_sec1_bytes()).is_ok());
+        assert!(secp256r1_verify(&msg_hash, &sig.to_bytes(), &vk.to_sec1_bytes()).is_ok());
 
         // incorrect private key
         let false_sk = SigningKey::random(&mut OsRng);
-        let false_sig: Signature = false_sk.sign_digest(msg.clone());
-        assert!(
-            secp256r1_verify(msg.as_bytes(), &false_sig.to_bytes(), &vk.to_sec1_bytes()).is_err()
-        );
+        let false_sig: Signature = false_sk.sign_digest(msg_hash.clone());
+        assert!(secp256r1_verify(&msg_hash, &false_sig.to_bytes(), &vk.to_sec1_bytes()).is_err());
 
         // incorrect public key
         let false_sk = SigningKey::random(&mut OsRng);
         let false_vk = VerifyingKey::from(&false_sk);
-        assert!(
-            secp256r1_verify(msg.as_bytes(), &sig.to_bytes(), &false_vk.to_sec1_bytes()).is_err()
-        );
+        assert!(secp256r1_verify(&msg_hash, &sig.to_bytes(), &false_vk.to_sec1_bytes()).is_err());
 
         // incorrect message
-        let false_prehash_msg = b"Larry";
-        let false_msg = sha2_256(false_prehash_msg);
-        assert!(secp256r1_verify(
-            &false_msg,
-            &sig.to_bytes(),
-            vk.to_encoded_point(true).as_bytes()
-        )
-        .is_err());
+        let false_msg = b"Larry";
+        let false_msg_hash = sha2_256(false_msg);
+        assert!(secp256r1_verify(&false_msg_hash, &sig.to_bytes(), &vk.to_sec1_bytes()).is_err());
     }
 }

--- a/crates/crypto/tests/rootberg.rs
+++ b/crates/crypto/tests/rootberg.rs
@@ -83,11 +83,14 @@ macro_rules! rootberg_test {
                 assert_eq!(test.$key_type.len(), $len);
 
                 eprintln!("Test case ID: {}", test.tc_id);
-                let message_hash = $hash_fn(&test.msg);
 
+                let message_hash = $hash_fn(&test.msg);
                 let signature = combine_signature(&test.sig);
+
                 match $verify_fn(&message_hash, &signature, &test.$key_type) {
-                    Ok(_) => assert!(test.valid),
+                    Ok(_) => {
+                        assert!(test.valid);
+                    },
                     Err(e) => {
                         assert!(!test.valid, "expected valid signature, got {:?}", e);
                     },


### PR DESCRIPTION
- Inconsistent use of terminology: 1) sometimes we use `prehash_msg` to mean the prehash and `msg` to mean the hash; 2) sometimes we use `msg` to mean the prehash and `msg_hash` to mean the hash.

  Fix: Now we consistently use (2).

- For Ed25519, we first hash the message with `sha2_256`, then call `sk.sign`. This is incorrect, because `sk.sign` performs a SHA2-512 hash before signing, so we effectively hash twice.

  Fix: The correct way is to first do `sha2_512`, then call `sk.sign_digest`. This involves adding the "digest" feature when importing ed25519-dalek, and adding a new `Identity512` type.

- For `ed25519_batch_verify`, there is only `sk.verify_batch` which takes a list of _prehash_ messsages; there isn't a method that takes a batch of _hashed_ messages. Therefore, unlike other functions in this crate, which all take hashes, this method takes prehashes. The function parameter name (`msgs_hash`) is therefore incorrect.

  Fix: I changed the parameter name (to `prehash_msgs`) to reflect this.

- Some minor styling changes in wycheproof/rootberg tests