### PR TITLE
Improvements to RustVm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "grug-testing",
  "grug-types",
  "serde",
+ "test-case",
  "thiserror",
 ]
 

--- a/crates/app/src/gas.rs
+++ b/crates/app/src/gas.rs
@@ -11,7 +11,7 @@ use {
 pub struct OutOfGasError {
     limit: u64,
     used: u64,
-    comment: String,
+    comment: &'static str,
 }
 
 struct GasTrackerInner {
@@ -85,7 +85,7 @@ impl GasTracker {
     /// Consume the given amount of gas. Error if the limit is exceeded.
     ///
     /// Panics if lock is poisoned.
-    pub fn consume(&self, consumed: u64, comment: &str) -> Result<(), OutOfGasError> {
+    pub fn consume(&self, consumed: u64, comment: &'static str) -> Result<(), OutOfGasError> {
         self.inner.write_with(|mut inner| {
             let used = inner.used + consumed;
 
@@ -98,7 +98,7 @@ impl GasTracker {
                     return Err(OutOfGasError {
                         limit,
                         used,
-                        comment: comment.to_string(),
+                        comment,
                     });
                 }
             }

--- a/crates/app/src/gas.rs
+++ b/crates/app/src/gas.rs
@@ -85,7 +85,7 @@ impl GasTracker {
     /// Consume the given amount of gas. Error if the limit is exceeded.
     ///
     /// Panics if lock is poisoned.
-    pub fn consume(&self, consumed: u64, _comment: &str) -> Result<(), OutOfGasError> {
+    pub fn consume(&self, consumed: u64, comment: &str) -> Result<(), OutOfGasError> {
         self.inner.write_with(|mut inner| {
             let used = inner.used + consumed;
 
@@ -93,23 +93,18 @@ impl GasTracker {
             if let Some(limit) = inner.limit {
                 if used > limit {
                     #[cfg(feature = "tracing")]
-                    tracing::warn!(limit = inner.limit, used, comment = _comment, "Out of gas");
+                    tracing::warn!(limit = inner.limit, used, comment, "Out of gas");
 
                     return Err(OutOfGasError {
                         limit,
                         used,
-                        comment: _comment.to_string(),
+                        comment: comment.to_string(),
                     });
                 }
             }
 
             #[cfg(feature = "tracing")]
-            tracing::debug!(
-                limit = inner.limit,
-                consumed,
-                comment = _comment,
-                "Gas consumed"
-            );
+            tracing::debug!(limit = inner.limit, consumed, comment, "Gas consumed");
 
             inner.used = used;
 

--- a/crates/app/src/traits.rs
+++ b/crates/app/src/traits.rs
@@ -111,13 +111,13 @@ pub trait Instance {
 
     /// Call a function that takes exactly 0 input parameter (other than the
     /// context) and returns exactly 1 output.
-    fn call_in_0_out_1(self, name: &str, ctx: &Context) -> Result<Vec<u8>, Self::Error>;
+    fn call_in_0_out_1(self, name: &'static str, ctx: &Context) -> Result<Vec<u8>, Self::Error>;
 
     /// Call a function that takes exactly 1 input parameter (other than the
     /// context) and returns exactly 1 output.
     fn call_in_1_out_1<P>(
         self,
-        name: &str,
+        name: &'static str,
         ctx: &Context,
         param: &P,
     ) -> Result<Vec<u8>, Self::Error>
@@ -128,7 +128,7 @@ pub trait Instance {
     /// context) and returns exactly 1 output.
     fn call_in_2_out_1<P1, P2>(
         self,
-        name: &str,
+        name: &'static str,
         ctx: &Context,
         param1: &P1,
         param2: &P2,

--- a/crates/types/src/macros.rs
+++ b/crates/types/src/macros.rs
@@ -1,16 +1,5 @@
 // -------------------------- generic error handling ---------------------------
 
-#[macro_export]
-#[doc(hidden)]
-macro_rules! return_into_generic_result {
-    ($expr:expr) => {
-        match $expr {
-            Ok(val) => GenericResult::Ok(val),
-            Err(err) => GenericResult::Err(err.to_string()),
-        }
-    };
-}
-
 // TODO: replace with https://doc.rust-lang.org/std/ops/trait.Try.html once stabilized
 #[macro_export]
 #[doc(hidden)]

--- a/crates/vm/rust/Cargo.toml
+++ b/crates/vm/rust/Cargo.toml
@@ -20,3 +20,4 @@ thiserror   = { workspace = true }
 [dev-dependencies]
 anyhow       = { workspace = true }
 grug-testing = { path = "../../testing" }
+test-case    = { workspace = true }

--- a/crates/vm/rust/README.md
+++ b/crates/vm/rust/README.md
@@ -1,0 +1,7 @@
+# grug-vm-rust
+
+An implementation of `grug_app::Vm` that runs native Rust code. Used for testing.
+
+## License
+
+TBD

--- a/crates/vm/rust/src/contract.rs
+++ b/crates/vm/rust/src/contract.rs
@@ -5,7 +5,7 @@ use {
     },
     elsa::sync::FrozenVec,
     grug_types::{
-        from_json_value, make_auth_ctx, make_immutable_ctx, make_mutable_ctx, make_sudo_ctx, Api,
+        from_json_slice, make_auth_ctx, make_immutable_ctx, make_mutable_ctx, make_sudo_ctx, Api,
         AuthCtx, BankMsg, BankQuery, BankQueryResponse, Binary, Context, Empty, GenericResult,
         ImmutableCtx, Json, MutableCtx, Querier, QuerierWrapper, Response, StdError, Storage,
         SubMsgResult, SudoCtx, Tx,
@@ -388,10 +388,10 @@ where
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Response>> {
         let mutable_ctx = make_mutable_ctx!(ctx, storage, api, querier);
-        let msg = from_json_value(msg)?;
+        let msg = from_json_slice(msg)?;
         let res = (self.instantiate_fn)(mutable_ctx, msg);
 
         Ok(res.into())
@@ -403,10 +403,10 @@ where
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Response>> {
         let mutable_ctx = make_mutable_ctx!(ctx, storage, api, querier);
-        let msg = from_json_value(msg)?;
+        let msg = from_json_slice(msg)?;
         // TODO: gracefully handle the `Option` instead of unwrapping??
         let res = self.execute_fn.as_ref().unwrap()(mutable_ctx, msg);
 
@@ -419,10 +419,10 @@ where
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Response>> {
         let mutable_ctx = make_mutable_ctx!(ctx, storage, api, querier);
-        let msg = from_json_value(msg)?;
+        let msg = from_json_slice(msg)?;
         let res = self.migrate_fn.as_ref().unwrap()(mutable_ctx, msg);
 
         Ok(res.into())
@@ -447,11 +447,11 @@ where
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
         submsg_res: SubMsgResult,
     ) -> VmResult<GenericResult<Response>> {
         let sudo_ctx = make_sudo_ctx!(ctx, storage, api, querier);
-        let msg = from_json_value(msg)?;
+        let msg = from_json_slice(msg)?;
         let res = self.reply_fn.as_ref().unwrap()(sudo_ctx, msg, submsg_res);
 
         Ok(res.into())
@@ -463,10 +463,10 @@ where
         storage: &dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Json>> {
         let immutable_ctx = make_immutable_ctx!(ctx, storage, api, querier);
-        let msg = from_json_value(msg)?;
+        let msg = from_json_slice(msg)?;
         let res = self.query_fn.as_ref().unwrap()(immutable_ctx, msg);
 
         Ok(res.into())

--- a/crates/vm/rust/src/contract.rs
+++ b/crates/vm/rust/src/contract.rs
@@ -16,7 +16,7 @@ use {
 
 static CONTRACTS: OnceLock<FrozenVec<Box<dyn Contract + Send + Sync>>> = OnceLock::new();
 
-pub fn get_contract_impl(
+pub(crate) fn get_contract_impl(
     wrapper: ContractWrapper,
 ) -> VmResult<&'static (dyn Contract + Send + Sync)> {
     CONTRACTS
@@ -357,7 +357,7 @@ where
 
 // ----------------------------------- impl ------------------------------------
 
-pub struct ContractImpl<M1, M2, M3, M5, M6, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11> {
+struct ContractImpl<M1, M2, M3, M5, M6, E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11> {
     instantiate_fn: InstantiateFn<M1, E1>,
     execute_fn: Option<ExecuteFn<M2, E2>>,
     migrate_fn: Option<MigrateFn<M3, E3>>,

--- a/crates/vm/rust/src/contract.rs
+++ b/crates/vm/rust/src/contract.rs
@@ -14,13 +14,22 @@ use {
     std::sync::OnceLock,
 };
 
-pub(crate) static CONTRACTS: OnceLock<FrozenVec<Box<dyn Contract + Send + Sync>>> = OnceLock::new();
+static CONTRACTS: OnceLock<FrozenVec<Box<dyn Contract + Send + Sync>>> = OnceLock::new();
+
+pub fn get_contract_impl(
+    wrapper: ContractWrapper,
+) -> VmResult<&'static (dyn Contract + Send + Sync)> {
+    CONTRACTS
+        .get_or_init(Default::default)
+        .get(wrapper.index)
+        .ok_or_else(|| VmError::contract_not_found(wrapper.index))
+}
 
 // ---------------------------------- wrapper ----------------------------------
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ContractWrapper {
-    pub(crate) index: usize,
+    index: usize,
 }
 
 impl<T> From<T> for ContractWrapper

--- a/crates/vm/rust/src/error.rs
+++ b/crates/vm/rust/src/error.rs
@@ -6,7 +6,7 @@ pub enum VmError {
     Std(#[from] StdError),
 
     #[error("attempting to call `{name}` with {num} inputs, but this function takes a different number of inputs")]
-    IncorrectNumberOfInputs { name: String, num: usize },
+    IncorrectNumberOfInputs { name: &'static str, num: usize },
 }
 
 impl From<VmError> for AppError {

--- a/crates/vm/rust/src/error.rs
+++ b/crates/vm/rust/src/error.rs
@@ -5,19 +5,22 @@ pub enum VmError {
     #[error(transparent)]
     Std(#[from] StdError),
 
-    #[error("attempting to call `{name}` with {num} inputs, but this function takes a different number of inputs")]
-    IncorrectNumberOfInputs { name: &'static str, num: usize },
+    #[error("contract with index `{index}` not found")]
+    ContractNotFound { index: usize },
 
     #[error("contract does not implement function `{name}`")]
     FunctionNotFound { name: &'static str },
 
     #[error("unknown function: `{name}`")]
     UnknownFunction { name: &'static str },
+
+    #[error("attempting to call `{name}` with {num} inputs, but this function takes a different number of inputs")]
+    IncorrectNumberOfInputs { name: &'static str, num: usize },
 }
 
 impl VmError {
-    pub const fn incorrect_number_of_inputs(name: &'static str, num: usize) -> Self {
-        Self::IncorrectNumberOfInputs { name, num }
+    pub const fn contract_not_found(index: usize) -> Self {
+        Self::ContractNotFound { index }
     }
 
     pub const fn function_not_found(name: &'static str) -> Self {
@@ -26,6 +29,10 @@ impl VmError {
 
     pub const fn unknown_function(name: &'static str) -> Self {
         Self::UnknownFunction { name }
+    }
+
+    pub const fn incorrect_number_of_inputs(name: &'static str, num: usize) -> Self {
+        Self::IncorrectNumberOfInputs { name, num }
     }
 }
 

--- a/crates/vm/rust/src/error.rs
+++ b/crates/vm/rust/src/error.rs
@@ -16,6 +16,10 @@ pub enum VmError {
 }
 
 impl VmError {
+    pub const fn incorrect_number_of_inputs(name: &'static str, num: usize) -> Self {
+        Self::IncorrectNumberOfInputs { name, num }
+    }
+
     pub const fn function_not_found(name: &'static str) -> Self {
         Self::FunctionNotFound { name }
     }

--- a/crates/vm/rust/src/error.rs
+++ b/crates/vm/rust/src/error.rs
@@ -10,11 +10,18 @@ pub enum VmError {
 
     #[error("contract does not implement function `{name}`")]
     FunctionNotFound { name: &'static str },
+
+    #[error("unknown function: `{name}`")]
+    UnknownFunction { name: &'static str },
 }
 
 impl VmError {
     pub const fn function_not_found(name: &'static str) -> Self {
         Self::FunctionNotFound { name }
+    }
+
+    pub const fn unknown_function(name: &'static str) -> Self {
+        Self::UnknownFunction { name }
     }
 }
 

--- a/crates/vm/rust/src/error.rs
+++ b/crates/vm/rust/src/error.rs
@@ -7,6 +7,15 @@ pub enum VmError {
 
     #[error("attempting to call `{name}` with {num} inputs, but this function takes a different number of inputs")]
     IncorrectNumberOfInputs { name: &'static str, num: usize },
+
+    #[error("contract does not implement function `{name}`")]
+    FunctionNotFound { name: &'static str },
+}
+
+impl VmError {
+    pub const fn function_not_found(name: &'static str) -> Self {
+        Self::FunctionNotFound { name }
+    }
 }
 
 impl From<VmError> for AppError {

--- a/crates/vm/rust/src/traits.rs
+++ b/crates/vm/rust/src/traits.rs
@@ -110,7 +110,7 @@ pub trait Contract {
     ) -> VmResult<GenericResult<Response>>;
 }
 
-// Trait aliases are unstable:
+// Trait alias is unstable:
 // https://doc.rust-lang.org/beta/unstable-book/language-features/trait-alias.html
 // So we define boxed traits as a workaround.
 

--- a/crates/vm/rust/src/traits.rs
+++ b/crates/vm/rust/src/traits.rs
@@ -2,9 +2,12 @@
 // https://stackoverflow.com/questions/59247458/is-there-a-stable-way-to-tell-rustfmt-to-skip-an-entire-file
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
-use grug_types::{
-    Api, AuthCtx, BankMsg, BankQuery, BankQueryResponse, Context, GenericResult, ImmutableCtx,
-    Json, MutableCtx, Querier, Response, Storage, SubMsgResult, SudoCtx, Tx,
+use {
+    crate::VmResult,
+    grug_types::{
+        Api, AuthCtx, BankMsg, BankQuery, BankQueryResponse, Context, GenericResult, ImmutableCtx,
+        Json, MutableCtx, Querier, Response, Storage, SubMsgResult, SudoCtx, Tx,
+    },
 };
 
 pub trait Contract {
@@ -15,7 +18,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         msg: Json,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn execute(
         &self,
@@ -24,7 +27,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         msg: Json,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn migrate(
         &self,
@@ -33,7 +36,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         msg: Json,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn receive(
         &self,
@@ -41,7 +44,7 @@ pub trait Contract {
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn reply(
         &self,
@@ -51,7 +54,7 @@ pub trait Contract {
         querier: &dyn Querier,
         msg: Json,
         submsg_res: SubMsgResult,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn query(
         &self,
@@ -60,7 +63,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         msg: Json,
-    ) -> GenericResult<Json>;
+    ) -> VmResult<GenericResult<Json>>;
 
     fn before_tx(
         &self,
@@ -69,7 +72,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         tx: Tx,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn after_tx(
         &self,
@@ -78,7 +81,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         tx: Tx,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn bank_execute(
         &self,
@@ -87,7 +90,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         msg: BankMsg,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 
     fn bank_query(
         &self,
@@ -96,7 +99,7 @@ pub trait Contract {
         api: &dyn Api,
         querier: &dyn Querier,
         msg: BankQuery,
-    ) -> GenericResult<BankQueryResponse>;
+    ) -> VmResult<GenericResult<BankQueryResponse>>;
 
     fn cron_execute(
         &self,
@@ -104,7 +107,7 @@ pub trait Contract {
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-    ) -> GenericResult<Response>;
+    ) -> VmResult<GenericResult<Response>>;
 }
 
 // Trait aliases are unstable:

--- a/crates/vm/rust/src/traits.rs
+++ b/crates/vm/rust/src/traits.rs
@@ -17,7 +17,7 @@ pub trait Contract {
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Response>>;
 
     fn execute(
@@ -26,7 +26,7 @@ pub trait Contract {
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Response>>;
 
     fn migrate(
@@ -35,7 +35,7 @@ pub trait Contract {
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Response>>;
 
     fn receive(
@@ -52,7 +52,7 @@ pub trait Contract {
         storage: &mut dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
         submsg_res: SubMsgResult,
     ) -> VmResult<GenericResult<Response>>;
 
@@ -62,7 +62,7 @@ pub trait Contract {
         storage: &dyn Storage,
         api: &dyn Api,
         querier: &dyn Querier,
-        msg: Json,
+        msg: &[u8],
     ) -> VmResult<GenericResult<Json>>;
 
     fn before_tx(

--- a/crates/vm/rust/src/vm.rs
+++ b/crates/vm/rust/src/vm.rs
@@ -77,11 +77,11 @@ impl Instance for RustInstance {
 
     fn call_in_0_out_1(mut self, name: &'static str, ctx: &Context) -> VmResult<Vec<u8>> {
         let contract = get_contract!(self.wrapper.index);
-        let out = match name {
+        match name {
             "receive" => {
                 let res =
                     contract.receive(ctx.clone(), &mut self.storage, &MockApi, &self.querier)?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "cron_execute" => {
                 let res = contract.cron_execute(
@@ -90,7 +90,7 @@ impl Instance for RustInstance {
                     &MockApi,
                     &self.querier,
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             _ if KNOWN_FUNCTIONS.contains(&name) => {
                 return Err(VmError::incorrect_number_of_inputs(name, 0));
@@ -98,8 +98,8 @@ impl Instance for RustInstance {
             _ => {
                 return Err(VmError::unknown_function(name));
             },
-        };
-        Ok(out)
+        }
+        .map_err(Into::into)
     }
 
     fn call_in_1_out_1<P>(
@@ -112,7 +112,7 @@ impl Instance for RustInstance {
         P: AsRef<[u8]>,
     {
         let contract = get_contract!(self.wrapper.index);
-        let out = match name {
+        match name {
             "instantiate" => {
                 let res = contract.instantiate(
                     ctx.clone(),
@@ -121,7 +121,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     param.as_ref(),
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "execute" => {
                 let res = contract.execute(
@@ -131,7 +131,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     param.as_ref(),
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "migrate" => {
                 let res = contract.migrate(
@@ -141,7 +141,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     param.as_ref(),
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "query" => {
                 let res = contract.query(
@@ -151,7 +151,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     param.as_ref(),
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "before_tx" => {
                 let tx = from_json_slice(param)?;
@@ -162,7 +162,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     tx,
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "after_tx" => {
                 let tx = from_json_slice(param)?;
@@ -173,7 +173,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     tx,
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "bank_execute" => {
                 let msg = from_json_slice(param)?;
@@ -184,7 +184,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     msg,
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             "bank_query" => {
                 let msg = from_json_slice(param)?;
@@ -195,7 +195,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     msg,
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             _ if KNOWN_FUNCTIONS.contains(&name) => {
                 return Err(VmError::incorrect_number_of_inputs(name, 1));
@@ -203,8 +203,8 @@ impl Instance for RustInstance {
             _ => {
                 return Err(VmError::unknown_function(name));
             },
-        };
-        Ok(out)
+        }
+        .map_err(Into::into)
     }
 
     fn call_in_2_out_1<P1, P2>(
@@ -219,7 +219,7 @@ impl Instance for RustInstance {
         P2: AsRef<[u8]>,
     {
         let contract = get_contract!(self.wrapper.index);
-        let out = match name {
+        match name {
             "reply" => {
                 let submsg_res = from_json_slice(param2)?;
                 let res = contract.reply(
@@ -230,7 +230,7 @@ impl Instance for RustInstance {
                     param1.as_ref(),
                     submsg_res,
                 )?;
-                to_json_vec(&res)?
+                to_json_vec(&res)
             },
             _ if KNOWN_FUNCTIONS.contains(&name) => {
                 return Err(VmError::incorrect_number_of_inputs(name, 2));
@@ -238,7 +238,7 @@ impl Instance for RustInstance {
             _ => {
                 return Err(VmError::unknown_function(name));
             },
-        };
-        Ok(out)
+        }
+        .map_err(Into::into)
     }
 }

--- a/crates/vm/rust/src/vm.rs
+++ b/crates/vm/rust/src/vm.rs
@@ -74,10 +74,7 @@ impl Instance for RustInstance {
                 to_json_vec(&res)?
             },
             _ => {
-                return Err(VmError::IncorrectNumberOfInputs {
-                    name: name.into(),
-                    num: 0,
-                })
+                return Err(VmError::IncorrectNumberOfInputs { name, num: 0 });
             },
         };
         Ok(out)
@@ -179,10 +176,7 @@ impl Instance for RustInstance {
                 to_json_vec(&res)?
             },
             _ => {
-                return Err(VmError::IncorrectNumberOfInputs {
-                    name: name.into(),
-                    num: 1,
-                })
+                return Err(VmError::IncorrectNumberOfInputs { name, num: 1 });
             },
         };
         Ok(out)
@@ -214,10 +208,7 @@ impl Instance for RustInstance {
                 to_json_vec(&res)?
             },
             _ => {
-                return Err(VmError::IncorrectNumberOfInputs {
-                    name: name.into(),
-                    num: 2,
-                })
+                return Err(VmError::IncorrectNumberOfInputs { name, num: 2 });
             },
         };
         Ok(out)

--- a/crates/vm/rust/src/vm.rs
+++ b/crates/vm/rust/src/vm.rs
@@ -95,42 +95,43 @@ impl Instance for RustInstance {
         let contract = get_contract!(self.wrapper.index);
         let out = match name {
             "instantiate" => {
-                let msg = from_json_slice(param)?;
                 let res = contract.instantiate(
                     ctx.clone(),
                     &mut self.storage,
                     &MockApi,
                     &self.querier,
-                    msg,
+                    param.as_ref(),
                 )?;
                 to_json_vec(&res)?
             },
             "execute" => {
-                let msg = from_json_slice(param)?;
                 let res = contract.execute(
                     ctx.clone(),
                     &mut self.storage,
                     &MockApi,
                     &self.querier,
-                    msg,
+                    param.as_ref(),
                 )?;
                 to_json_vec(&res)?
             },
             "migrate" => {
-                let msg = from_json_slice(param)?;
                 let res = contract.migrate(
                     ctx.clone(),
                     &mut self.storage,
                     &MockApi,
                     &self.querier,
-                    msg,
+                    param.as_ref(),
                 )?;
                 to_json_vec(&res)?
             },
             "query" => {
-                let msg = from_json_slice(param)?;
-                let res =
-                    contract.query(ctx.clone(), &self.storage, &MockApi, &self.querier, msg)?;
+                let res = contract.query(
+                    ctx.clone(),
+                    &self.storage,
+                    &MockApi,
+                    &self.querier,
+                    param.as_ref(),
+                )?;
                 to_json_vec(&res)?
             },
             "before_tx" => {
@@ -201,14 +202,13 @@ impl Instance for RustInstance {
         let contract = get_contract!(self.wrapper.index);
         let out = match name {
             "reply" => {
-                let msg = from_json_slice(param1)?;
                 let submsg_res = from_json_slice(param2)?;
                 let res = contract.reply(
                     ctx.clone(),
                     &mut self.storage,
                     &MockApi,
                     &self.querier,
-                    msg,
+                    param1.as_ref(),
                     submsg_res,
                 )?;
                 to_json_vec(&res)?

--- a/crates/vm/rust/src/vm.rs
+++ b/crates/vm/rust/src/vm.rs
@@ -56,7 +56,7 @@ pub struct RustInstance {
 impl Instance for RustInstance {
     type Error = VmError;
 
-    fn call_in_0_out_1(mut self, name: &str, ctx: &Context) -> VmResult<Vec<u8>> {
+    fn call_in_0_out_1(mut self, name: &'static str, ctx: &Context) -> VmResult<Vec<u8>> {
         let contract = get_contract!(self.wrapper.index);
         let out = match name {
             "receive" => {
@@ -78,7 +78,12 @@ impl Instance for RustInstance {
         Ok(out)
     }
 
-    fn call_in_1_out_1<P>(mut self, name: &str, ctx: &Context, param: &P) -> VmResult<Vec<u8>>
+    fn call_in_1_out_1<P>(
+        mut self,
+        name: &'static str,
+        ctx: &Context,
+        param: &P,
+    ) -> VmResult<Vec<u8>>
     where
         P: AsRef<[u8]>,
     {
@@ -153,7 +158,7 @@ impl Instance for RustInstance {
 
     fn call_in_2_out_1<P1, P2>(
         mut self,
-        name: &str,
+        name: &'static str,
         ctx: &Context,
         param1: &P1,
         param2: &P2,

--- a/crates/vm/rust/src/vm.rs
+++ b/crates/vm/rust/src/vm.rs
@@ -93,7 +93,7 @@ impl Instance for RustInstance {
                 to_json_vec(&res)?
             },
             _ if KNOWN_FUNCTIONS.contains(&name) => {
-                return Err(VmError::IncorrectNumberOfInputs { name, num: 0 });
+                return Err(VmError::incorrect_number_of_inputs(name, 0));
             },
             _ => {
                 return Err(VmError::unknown_function(name));
@@ -198,7 +198,7 @@ impl Instance for RustInstance {
                 to_json_vec(&res)?
             },
             _ if KNOWN_FUNCTIONS.contains(&name) => {
-                return Err(VmError::IncorrectNumberOfInputs { name, num: 1 });
+                return Err(VmError::incorrect_number_of_inputs(name, 1));
             },
             _ => {
                 return Err(VmError::unknown_function(name));
@@ -233,7 +233,7 @@ impl Instance for RustInstance {
                 to_json_vec(&res)?
             },
             _ if KNOWN_FUNCTIONS.contains(&name) => {
-                return Err(VmError::IncorrectNumberOfInputs { name, num: 2 });
+                return Err(VmError::incorrect_number_of_inputs(name, 2));
             },
             _ => {
                 return Err(VmError::unknown_function(name));

--- a/crates/vm/rust/src/vm.rs
+++ b/crates/vm/rust/src/vm.rs
@@ -60,12 +60,17 @@ impl Instance for RustInstance {
         let contract = get_contract!(self.wrapper.index);
         let out = match name {
             "receive" => {
-                let res = contract.receive(ctx.clone(), &mut self.storage, &MockApi, &self.querier);
+                let res =
+                    contract.receive(ctx.clone(), &mut self.storage, &MockApi, &self.querier)?;
                 to_json_vec(&res)?
             },
             "cron_execute" => {
-                let res =
-                    contract.cron_execute(ctx.clone(), &mut self.storage, &MockApi, &self.querier);
+                let res = contract.cron_execute(
+                    ctx.clone(),
+                    &mut self.storage,
+                    &MockApi,
+                    &self.querier,
+                )?;
                 to_json_vec(&res)?
             },
             _ => {
@@ -97,36 +102,57 @@ impl Instance for RustInstance {
                     &MockApi,
                     &self.querier,
                     msg,
-                );
+                )?;
                 to_json_vec(&res)?
             },
             "execute" => {
                 let msg = from_json_slice(param)?;
-                let res =
-                    contract.execute(ctx.clone(), &mut self.storage, &MockApi, &self.querier, msg);
+                let res = contract.execute(
+                    ctx.clone(),
+                    &mut self.storage,
+                    &MockApi,
+                    &self.querier,
+                    msg,
+                )?;
                 to_json_vec(&res)?
             },
             "migrate" => {
                 let msg = from_json_slice(param)?;
-                let res =
-                    contract.migrate(ctx.clone(), &mut self.storage, &MockApi, &self.querier, msg);
+                let res = contract.migrate(
+                    ctx.clone(),
+                    &mut self.storage,
+                    &MockApi,
+                    &self.querier,
+                    msg,
+                )?;
                 to_json_vec(&res)?
             },
             "query" => {
                 let msg = from_json_slice(param)?;
-                let res = contract.query(ctx.clone(), &self.storage, &MockApi, &self.querier, msg);
+                let res =
+                    contract.query(ctx.clone(), &self.storage, &MockApi, &self.querier, msg)?;
                 to_json_vec(&res)?
             },
             "before_tx" => {
                 let tx = from_json_slice(param)?;
-                let res =
-                    contract.before_tx(ctx.clone(), &mut self.storage, &MockApi, &self.querier, tx);
+                let res = contract.before_tx(
+                    ctx.clone(),
+                    &mut self.storage,
+                    &MockApi,
+                    &self.querier,
+                    tx,
+                )?;
                 to_json_vec(&res)?
             },
             "after_tx" => {
                 let tx = from_json_slice(param)?;
-                let res =
-                    contract.after_tx(ctx.clone(), &mut self.storage, &MockApi, &self.querier, tx);
+                let res = contract.after_tx(
+                    ctx.clone(),
+                    &mut self.storage,
+                    &MockApi,
+                    &self.querier,
+                    tx,
+                )?;
                 to_json_vec(&res)?
             },
             "bank_execute" => {
@@ -137,13 +163,18 @@ impl Instance for RustInstance {
                     &MockApi,
                     &self.querier,
                     msg,
-                );
+                )?;
                 to_json_vec(&res)?
             },
             "bank_query" => {
                 let msg = from_json_slice(param)?;
-                let res =
-                    contract.bank_query(ctx.clone(), &self.storage, &MockApi, &self.querier, msg);
+                let res = contract.bank_query(
+                    ctx.clone(),
+                    &self.storage,
+                    &MockApi,
+                    &self.querier,
+                    msg,
+                )?;
                 to_json_vec(&res)?
             },
             _ => {
@@ -179,7 +210,7 @@ impl Instance for RustInstance {
                     &self.querier,
                     msg,
                     submsg_res,
-                );
+                )?;
                 to_json_vec(&res)?
             },
             _ => {

--- a/crates/vm/rust/src/vm.rs
+++ b/crates/vm/rust/src/vm.rs
@@ -344,7 +344,8 @@ mod tests {
             },
             // We expect the call to fail. Check that the error message is as
             // expected.
-            // Here we have to compare the error as strings, because we can't
+            //
+            // Here we have to compare the errors as strings, because we can't
             // derive `PartialEq` on `VmError`. This is because `VmError`
             // inherits `StdError`, which inherits `TryFromSliceError`, which
             // doesn't implement `PartialEq`.

--- a/crates/vm/wasm/src/environment.rs
+++ b/crates/vm/wasm/src/environment.rs
@@ -142,7 +142,7 @@ impl Environment {
     pub fn call_function1<S>(
         &mut self,
         store: &mut S,
-        name: &str,
+        name: &'static str,
         args: &[Value],
     ) -> VmResult<Value>
     where
@@ -159,7 +159,12 @@ impl Environment {
         Ok(ret[0].clone())
     }
 
-    pub fn call_function0<S>(&mut self, store: &mut S, name: &str, args: &[Value]) -> VmResult<()>
+    pub fn call_function0<S>(
+        &mut self,
+        store: &mut S,
+        name: &'static str,
+        args: &[Value],
+    ) -> VmResult<()>
     where
         S: AsStoreMut,
     {
@@ -177,7 +182,7 @@ impl Environment {
     fn call_function<S>(
         &mut self,
         store: &mut S,
-        name: &str,
+        name: &'static str,
         args: &[Value],
     ) -> VmResult<Box<[Value]>>
     where
@@ -232,7 +237,7 @@ impl Environment {
         &mut self,
         store: &mut S,
         external: u64,
-        comment: &str,
+        comment: &'static str,
     ) -> VmResult<()>
     where
         S: AsStoreMut,

--- a/crates/vm/wasm/src/vm.rs
+++ b/crates/vm/wasm/src/vm.rs
@@ -166,7 +166,7 @@ pub struct WasmInstance {
 impl Instance for WasmInstance {
     type Error = VmError;
 
-    fn call_in_0_out_1(mut self, name: &str, ctx: &Context) -> VmResult<Vec<u8>> {
+    fn call_in_0_out_1(mut self, name: &'static str, ctx: &Context) -> VmResult<Vec<u8>> {
         let mut fe_mut = self.fe.clone().into_mut(&mut self.store);
         let (env, mut store) = fe_mut.data_and_store_mut();
 
@@ -181,7 +181,12 @@ impl Instance for WasmInstance {
         Ok(data)
     }
 
-    fn call_in_1_out_1<P>(mut self, name: &str, ctx: &Context, param: &P) -> VmResult<Vec<u8>>
+    fn call_in_1_out_1<P>(
+        mut self,
+        name: &'static str,
+        ctx: &Context,
+        param: &P,
+    ) -> VmResult<Vec<u8>>
     where
         P: AsRef<[u8]>,
     {
@@ -202,7 +207,7 @@ impl Instance for WasmInstance {
 
     fn call_in_2_out_1<P1, P2>(
         mut self,
-        name: &str,
+        name: &'static str,
         ctx: &Context,
         param1: &P1,
         param2: &P2,


### PR DESCRIPTION
- Use `&'static str` instead of `String` for function names
- Adjust `grug_vm_rust::Contract` method signatures:
  - Return `VmResult<GenericResult<T>>` instead of `GenericResult<T>`. The `VmResult` means an error happened at the VM level; the `GenericResult` means an error happened inside the contract.
  - Take `msg: &[u8]` instead of `msg: Json`. This prevents some unnecessary serializations.
- Gracefully handle the case where a contract doesn't implement a function. (Added: `VmError::FunctionNotFound`)
- Handle the case where the caller attempts to call an unknown/unsupported function. (Added: `VmError::UnknownFunction`)
- Handle the case where the contract is not found with the given index. (Added: `VmError::ContractNotFound`)