### PR TITLE
Multi query

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -817,6 +817,21 @@ where
             let res = query_wasm_smart(vm, storage, block, gas_tracker, contract, msg)?;
             Ok(QueryResponse::WasmSmart(res))
         },
+        QueryRequest::Multi(reqs) => {
+            let res = reqs
+                .into_iter()
+                .map(|req| {
+                    process_query(
+                        vm.clone(),
+                        storage.clone(),
+                        gas_tracker.clone(),
+                        block.clone(),
+                        req,
+                    )
+                })
+                .collect::<AppResult<Vec<_>>>()?;
+            Ok(QueryResponse::Multi(res))
+        },
     }
 }
 

--- a/crates/testing/tests/queries.rs
+++ b/crates/testing/tests/queries.rs
@@ -1,0 +1,53 @@
+use {
+    grug_testing::TestBuilder,
+    grug_types::{Coins, Empty, NonZero},
+    grug_vm_rust::ContractBuilder,
+};
+
+mod query_maker {
+    use {
+        anyhow::ensure,
+        grug_types::{Empty, MutableCtx, Number, QueryRequest, Response, Uint256},
+    };
+
+    pub fn instantiate(ctx: MutableCtx, _msg: Empty) -> anyhow::Result<Response> {
+        // Attempt to make a multi query.
+        let [res1, res2, res3] = ctx.querier.query_multi([
+            QueryRequest::Info {},
+            QueryRequest::Balance {
+                address: ctx.contract,
+                denom: "uusdc".to_string(),
+            },
+            QueryRequest::Supply {
+                denom: "uusdc".to_string(),
+            },
+        ])?;
+
+        ensure!(res1.as_info().chain_id == "kebab");
+        ensure!(res2.as_balance().amount.is_zero());
+        ensure!(res3.as_supply().amount == Uint256::from(123_u128));
+
+        Ok(Response::new())
+    }
+}
+
+#[test]
+fn handling_multi_query() -> anyhow::Result<()> {
+    let (mut suite, accounts) = TestBuilder::new()
+        .add_account("larry", Coins::one("uusdc", NonZero::new(123_u128)))?
+        .set_chain_id("kebab")
+        .build()?;
+
+    let query_maker_code = ContractBuilder::new(Box::new(query_maker::instantiate)).build();
+
+    // If the contract successfully deploys, the multi query must have worked.
+    suite.upload_and_instantiate(
+        &accounts["larry"],
+        query_maker_code,
+        "query_maker",
+        &Empty {},
+        Coins::new(),
+    )?;
+
+    Ok(())
+}

--- a/crates/types/src/query.rs
+++ b/crates/types/src/query.rs
@@ -56,6 +56,9 @@ pub enum QueryRequest {
     /// Call the contract's query entry point with the given message.
     /// Returns: `Json`
     WasmSmart { contract: Addr, msg: Json },
+    /// Perform multiple queries at once.
+    /// Returns: `Vec<QueryResponse>`.
+    Multi(Vec<QueryRequest>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -79,6 +82,7 @@ pub enum QueryResponse {
     Accounts(BTreeMap<Addr, Account>),
     WasmRaw(Option<Binary>),
     WasmSmart(Json),
+    Multi(Vec<QueryResponse>),
 }
 
 // TODO: can we use a macro to implement these?
@@ -156,6 +160,13 @@ impl QueryResponse {
     pub fn as_wasm_smart(self) -> Json {
         let Self::WasmSmart(resp) = self else {
             panic!("QueryResponse is not WasmSmart");
+        };
+        resp
+    }
+
+    pub fn as_multi(self) -> Vec<QueryResponse> {
+        let Self::Multi(resp) = self else {
+            panic!("QueryResponse is not Multi");
         };
         resp
     }


### PR DESCRIPTION
1. FFI can be a bottleneck in performance. If a contract needs to make multiple queries, it may be more efficient to bundle them into a single FFI call. 
2. This also allows clients to make only a single HTTP query to the node.