### PR TITLE
Add JSON string methods; more details to error messages

### DIFF
--- a/crates/storage/src/key.rs
+++ b/crates/storage/src/key.rs
@@ -111,6 +111,7 @@ impl Key for () {
     fn from_slice(bytes: &[u8]) -> StdResult<Self::Output> {
         if !bytes.is_empty() {
             return Err(StdError::deserialize::<Self::Output, _>(
+                "key",
                 "expecting empty bytes",
             ));
         }
@@ -157,7 +158,8 @@ impl Key for &str {
     }
 
     fn from_slice(bytes: &[u8]) -> StdResult<Self::Output> {
-        String::from_utf8(bytes.to_vec()).map_err(StdError::deserialize::<Self::Output, _>)
+        String::from_utf8(bytes.to_vec())
+            .map_err(|err| StdError::deserialize::<Self::Output, _>("key", err))
     }
 }
 
@@ -171,7 +173,8 @@ impl Key for String {
     }
 
     fn from_slice(bytes: &[u8]) -> StdResult<Self::Output> {
-        String::from_utf8(bytes.to_vec()).map_err(StdError::deserialize::<Self::Output, _>)
+        String::from_utf8(bytes.to_vec())
+            .map_err(|err| StdError::deserialize::<Self::Output, _>("key", err))
     }
 }
 
@@ -369,11 +372,14 @@ macro_rules! impl_integer_key {
 
             fn from_slice(bytes: &[u8]) -> StdResult<Self::Output> {
                 let Ok(bytes) = <[u8; mem::size_of::<Self>()]>::try_from(bytes) else {
-                    return Err(StdError::deserialize::<Self::Output, _>(format!(
-                        "wrong number of bytes: expecting {}, got {}",
-                        mem::size_of::<Self>(),
-                        bytes.len(),
-                    )));
+                    return Err(StdError::deserialize::<Self::Output, _>(
+                        "key",
+                        format!(
+                            "wrong number of bytes: expecting {}, got {}",
+                            mem::size_of::<Self>(),
+                            bytes.len(),
+                        ),
+                    ));
                 };
 
                 Ok(Self::from_be_bytes(bytes))

--- a/crates/types/src/address.rs
+++ b/crates/types/src/address.rs
@@ -109,7 +109,10 @@ impl Addr {
         let addr = Addr::from_str(s)?;
 
         if s != addr.to_erc55_string() {
-            return Err(StdError::deserialize::<Self, _>("invalid ERC-55 checksum"));
+            return Err(StdError::deserialize::<Self, _>(
+                "hex",
+                "invalid ERC-55 checksum",
+            ));
         }
 
         Ok(addr)
@@ -148,6 +151,7 @@ impl TryFrom<Vec<u8>> for Addr {
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
         let Ok(bytes) = bytes.try_into() else {
             return Err(StdError::deserialize::<Self, _>(
+                "hex",
                 "address is not of the correct length",
             ));
         };
@@ -162,6 +166,7 @@ impl TryFrom<&[u8]> for Addr {
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         let Ok(bytes) = bytes.try_into() else {
             return Err(StdError::deserialize::<Self, _>(
+                "hex",
                 "address is not of the correct length",
             ));
         };
@@ -177,7 +182,7 @@ impl FromStr for Addr {
         // The address must have the `0x` prefix.
         let hex_str = s
             .strip_prefix(Self::PREFIX)
-            .ok_or_else(|| StdError::deserialize::<Self, _>("incorrect address prefix"))?;
+            .ok_or_else(|| StdError::deserialize::<Self, _>("hex", "incorrect address prefix"))?;
 
         // Decode the hex string
         let bytes = hex::decode(hex_str)?;

--- a/crates/types/src/db.rs
+++ b/crates/types/src/db.rs
@@ -68,7 +68,7 @@ impl TryFrom<i32> for Order {
             2 => Ok(Order::Descending),
             _ => {
                 let reason = format!("must be 1 (asc) or 2 (desc), found {value}");
-                Err(StdError::deserialize::<Self, _>(reason))
+                Err(StdError::deserialize::<Self, _>("index", reason))
             },
         }
     }

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -124,11 +124,19 @@ pub enum StdError {
     #[error("logarithm of zero")]
     ZeroLog,
 
-    #[error("failed to serialize into json! type: {ty}, reason: {reason}")]
-    Serialize { ty: &'static str, reason: String },
+    #[error("failed to serialize into json! codec: {codec}, type: {ty}, reason: {reason}")]
+    Serialize {
+        codec: &'static str,
+        ty: &'static str,
+        reason: String,
+    },
 
-    #[error("failed to deserialize from json! type: {ty}, reason: {reason}")]
-    Deserialize { ty: &'static str, reason: String },
+    #[error("failed to deserialize from json! codec: {codec}, type: {ty}, reason: {reason}")]
+    Deserialize {
+        codec: &'static str,
+        ty: &'static str,
+        reason: String,
+    },
 }
 
 impl StdError {
@@ -288,21 +296,23 @@ impl StdError {
         Self::NegativeSqrt { a: a.to_string() }
     }
 
-    pub fn serialize<T, R>(reason: R) -> Self
+    pub fn serialize<T, R>(codec: &'static str, reason: R) -> Self
     where
         R: ToString,
     {
         Self::Serialize {
+            codec,
             ty: type_name::<T>(),
             reason: reason.to_string(),
         }
     }
 
-    pub fn deserialize<T, R>(reason: R) -> Self
+    pub fn deserialize<T, R>(codec: &'static str, reason: R) -> Self
     where
         R: ToString,
     {
         Self::Deserialize {
+            codec,
             ty: type_name::<T>(),
             reason: reason.to_string(),
         }

--- a/crates/types/src/hash.rs
+++ b/crates/types/src/hash.rs
@@ -79,6 +79,7 @@ impl<const N: usize> TryFrom<Vec<u8>> for Hash<N> {
     fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
         let Ok(bytes) = bytes.try_into() else {
             return Err(StdError::deserialize::<Self, _>(
+                "hex",
                 "hash is not of the correct length",
             ));
         };
@@ -93,6 +94,7 @@ impl<const N: usize> TryFrom<&[u8]> for Hash<N> {
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         let Ok(bytes) = bytes.try_into() else {
             return Err(StdError::deserialize::<Self, _>(
+                "hex",
                 "hash is not of the correct length",
             ));
         };
@@ -110,6 +112,7 @@ impl<const N: usize> FromStr for Hash<N> {
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
         {
             return Err(StdError::deserialize::<Self, _>(
+                "hex",
                 "hash must only contain uppercase alphanumeric characters",
             ));
         }

--- a/crates/types/src/serializers.rs
+++ b/crates/types/src/serializers.rs
@@ -10,7 +10,7 @@ pub fn from_json_value<T>(json: Json) -> StdResult<T>
 where
     T: DeserializeOwned,
 {
-    serde_json::from_value(json).map_err(StdError::deserialize::<T, _>)
+    serde_json::from_value(json).map_err(|err| StdError::deserialize::<T, _>("json", err))
 }
 
 /// Serialize a Rust value into JSON value.
@@ -18,7 +18,7 @@ pub fn to_json_value<T>(data: &T) -> StdResult<Json>
 where
     T: Serialize,
 {
-    serde_json::to_value(data).map_err(StdError::serialize::<T, _>)
+    serde_json::to_value(data).map_err(|err| StdError::serialize::<T, _>("json", err))
 }
 
 /// Deserialize a slice of bytes into Rust value of a given type `T` using the
@@ -28,7 +28,7 @@ where
     B: AsRef<[u8]>,
     T: DeserializeOwned,
 {
-    serde_json::from_slice(bytes.as_ref()).map_err(StdError::deserialize::<T, _>)
+    serde_json::from_slice(bytes.as_ref()).map_err(|err| StdError::deserialize::<T, _>("json", err))
 }
 
 /// Serialize a Rust value into bytes using the JSON encoding scheme.
@@ -36,7 +36,32 @@ pub fn to_json_vec<T>(data: &T) -> StdResult<Vec<u8>>
 where
     T: Serialize,
 {
-    serde_json::to_vec(data).map_err(StdError::serialize::<T, _>)
+    serde_json::to_vec(data).map_err(|err| StdError::serialize::<T, _>("json", err))
+}
+
+/// Deserialize a JSON string into Rust value of a given type `T`.
+pub fn from_json_str<S, T>(string: S) -> StdResult<T>
+where
+    S: AsRef<str>,
+    T: DeserializeOwned,
+{
+    serde_json::from_str(string.as_ref()).map_err(|err| StdError::deserialize::<T, _>("json", err))
+}
+
+/// Serialize a Rust value into a JSON string.
+pub fn to_json_string<T>(data: &T) -> StdResult<String>
+where
+    T: Serialize,
+{
+    serde_json::to_string(data).map_err(|err| StdError::serialize::<T, _>("json", err))
+}
+
+/// Serialize a Rust value into a a pretty JSON string.
+pub fn to_json_string_pretty<T>(data: &T) -> StdResult<String>
+where
+    T: Serialize,
+{
+    serde_json::to_string_pretty(data).map_err(|err| StdError::serialize::<T, _>("json", err))
 }
 
 /// Deserialize a slice of bytes into Rust value of a given type `T` using the
@@ -46,7 +71,7 @@ where
     B: AsRef<[u8]>,
     T: BorshDeserialize,
 {
-    borsh::from_slice(bytes.as_ref()).map_err(StdError::deserialize::<T, _>)
+    borsh::from_slice(bytes.as_ref()).map_err(|err| StdError::deserialize::<T, _>("borsh", err))
 }
 
 /// Serialize a Rust value into bytes using the [Borsh](https://crates.io/crates/borsh)
@@ -55,7 +80,7 @@ pub fn to_borsh_vec<T>(data: &T) -> StdResult<Vec<u8>>
 where
     T: BorshSerialize,
 {
-    borsh::to_vec(data).map_err(StdError::serialize::<T, _>)
+    borsh::to_vec(data).map_err(|err| StdError::serialize::<T, _>("borsh", err))
 }
 
 /// Deserialize a slice of bytes into Rust value of a given type `T` using the
@@ -65,7 +90,7 @@ where
     B: AsRef<[u8]>,
     T: Message + Default,
 {
-    T::decode(bytes.as_ref()).map_err(StdError::deserialize::<T, _>)
+    T::decode(bytes.as_ref()).map_err(|err| StdError::deserialize::<T, _>("protobuf", err))
 }
 
 /// Serialize a Rust value into bytes using the Protobuf encoding scheme.


### PR DESCRIPTION
1. Add method to serialize to / deserialize from JSON strings
2. Add the name of the codec to `StdError::{Serialize,Deserialize}` error messages