### PR TITLE
Signer trait

### DIFF
--- a/crates/testing/src/account.rs
+++ b/crates/testing/src/account.rs
@@ -9,7 +9,7 @@ use {
 
 /// Describes an account that is capable of signing transactions.
 pub trait Signer {
-    /// Return an owned copy of the signer's address.
+    /// Return the signer's address.
     fn address(&self) -> Addr;
 
     /// Given a list of messages and relevant metadata, produce a signed transaction.

--- a/crates/testing/src/account.rs
+++ b/crates/testing/src/account.rs
@@ -1,13 +1,26 @@
 use {
     grug_account::{Credential, PublicKey},
     grug_crypto::{sha2_256, Identity256},
-    grug_types::{to_json_value, Addr, Hash256, Json, Message, Tx, GENESIS_SENDER},
+    grug_types::{to_json_value, Addr, Hash256, Json, Message, StdResult, Tx, GENESIS_SENDER},
     k256::ecdsa::{signature::DigestSigner, Signature, SigningKey},
     rand::rngs::OsRng,
     std::collections::HashMap,
 };
 
-pub type TestAccounts = HashMap<&'static str, TestAccount>;
+/// Describes an account that is capable of signing transactions.
+pub trait Signer {
+    /// Return an owned copy of the signer's address.
+    fn address(&self) -> Addr;
+
+    /// Given a list of messages and relevant metadata, produce a signed transaction.
+    fn sign_transaction(
+        &self,
+        msgs: Vec<Message>,
+        gas_limit: u64,
+        chain_id: &str,
+        sequence: u32,
+    ) -> StdResult<Tx>;
+}
 
 pub struct TestAccount {
     pub address: Addr,
@@ -29,14 +42,20 @@ impl TestAccount {
 
         Self { address, sk, pk }
     }
+}
 
-    pub fn sign_transaction(
+impl Signer for TestAccount {
+    fn address(&self) -> Addr {
+        self.address
+    }
+
+    fn sign_transaction(
         &self,
         msgs: Vec<Message>,
         gas_limit: u64,
         chain_id: &str,
         sequence: u32,
-    ) -> anyhow::Result<Tx> {
+    ) -> StdResult<Tx> {
         let sign_bytes = Identity256::from(grug_account::make_sign_bytes(
             sha2_256,
             &msgs,
@@ -61,3 +80,5 @@ impl TestAccount {
         })
     }
 }
+
+pub type TestAccounts = HashMap<&'static str, TestAccount>;

--- a/crates/testing/tests/account.rs
+++ b/crates/testing/tests/account.rs
@@ -1,6 +1,6 @@
 use {
     grug_account::Credential,
-    grug_testing::TestBuilder,
+    grug_testing::{Signer, TestBuilder},
     grug_types::{
         from_json_value, Coins, Duration, Message, NonZero, NumberConst, Timestamp, Tx, Uint256,
     },


### PR DESCRIPTION
Our app uses different sign bytes than the mock account in this repo, so in order to use the `TestSuite` in the app, we need to abstract test accounts as a trait.