### PR TITLE
Better counter

### DIFF
--- a/contracts/account/src/query.rs
+++ b/contracts/account/src/query.rs
@@ -6,6 +6,6 @@ use {
 pub fn query_state(storage: &dyn Storage) -> StdResult<StateResponse> {
     Ok(StateResponse {
         public_key: PUBLIC_KEY.load(storage)?,
-        sequence: SEQUENCE.load(storage)?,
+        sequence: SEQUENCE.current(storage)?,
     })
 }

--- a/contracts/account/src/state.rs
+++ b/contracts/account/src/state.rs
@@ -7,4 +7,4 @@ use {
 pub const PUBLIC_KEY: Item<PublicKey> = Item::new("pk");
 
 /// The account's sequence number, also known as "nonce" in Ethereum.
-pub const SEQUENCE: Counter<u32> = Counter::new("seq");
+pub const SEQUENCE: Counter<u32> = Counter::new("seq", 0, 1);

--- a/crates/storage/src/counter.rs
+++ b/crates/storage/src/counter.rs
@@ -1,57 +1,48 @@
 use {
     crate::{Borsh, Codec, Item},
-    grug_types::{Number, NumberConst, StdResult, Storage},
+    grug_types::{Number, StdResult, Storage},
 };
 
 /// An abstraction over `Item`. Stores a single number that is monotonically
 /// incremented one unit at a time.
 pub struct Counter<'a, T, C = Borsh>
 where
+    T: Number + Copy,
     C: Codec<T>,
 {
     item: Item<'a, T, C>,
+    base: T,
+    step: T,
 }
 
 impl<'a, T, C> Counter<'a, T, C>
 where
+    T: Number + Copy,
     C: Codec<T>,
 {
-    pub const fn new(storage_key: &'a str) -> Self {
+    pub const fn new(storage_key: &'a str, base: T, step: T) -> Self {
         Self {
             item: Item::new(storage_key),
+            base,
+            step,
         }
     }
 
     /// Load the current counter value.
-    ///
-    /// Error if the counter has not been initialized.
-    pub fn load(&self, storage: &dyn Storage) -> StdResult<T> {
-        self.item.load(storage)
-    }
-}
-
-impl<'a, T, C> Counter<'a, T, C>
-where
-    T: Number + NumberConst,
-    C: Codec<T>,
-{
-    /// Initialize the incrementor to the zero value.
-    ///
-    /// This is typically done during contract instantiation.
-    pub fn initialize(&self, storage: &mut dyn Storage) -> StdResult<()> {
-        self.item.save(storage, &T::ZERO)
+    pub fn current(&self, storage: &dyn Storage) -> StdResult<T> {
+        self.item
+            .may_load(storage)
+            .map(|maybe_value| maybe_value.unwrap_or(self.base))
     }
 
-    /// Increment the value stored by one unit; return the value _after_
-    /// incrementing. If no value is stored, set it to zero and return zero.
-    pub fn increment(&self, storage: &mut dyn Storage) -> StdResult<T> {
-        let new_value = match self.item.may_load(storage)? {
-            Some(old_value) => old_value.checked_add(T::ONE)?,
-            None => T::ZERO,
-        };
+    /// Increment the value stored by one unit; return the values before and
+    /// after incrementing.
+    pub fn increment(&self, storage: &mut dyn Storage) -> StdResult<(T, T)> {
+        let old_value = self.current(storage)?;
+        let new_value = old_value.checked_add(self.step)?;
 
         self.item.save(storage, &new_value)?;
 
-        Ok(new_value)
+        Ok((old_value, new_value))
     }
 }

--- a/crates/storage/src/counter.rs
+++ b/crates/storage/src/counter.rs
@@ -1,13 +1,13 @@
 use {
-    crate::{Borsh, Codec, Item},
+    crate::{Borsh, Codec, Item, Key, Map},
     grug_types::{Number, StdResult, Storage},
 };
 
-/// An abstraction over `Item`. Stores a single number that is monotonically
-/// incremented one unit at a time.
+/// A single number that is monotonically incremented by the given step size.
+///
+/// In internally, this is an abstraction over an [`Item`](crate::Item).
 pub struct Counter<'a, T, C = Borsh>
 where
-    T: Number + Copy,
     C: Codec<T>,
 {
     item: Item<'a, T, C>,
@@ -35,13 +35,63 @@ where
             .map(|maybe_value| maybe_value.unwrap_or(self.base))
     }
 
-    /// Increment the value stored by one unit; return the values before and
-    /// after incrementing.
+    /// Increment the value by the step size; return the values before and after
+    /// incrementing.
     pub fn increment(&self, storage: &mut dyn Storage) -> StdResult<(T, T)> {
         let old_value = self.current(storage)?;
         let new_value = old_value.checked_add(self.step)?;
 
         self.item.save(storage, &new_value)?;
+
+        Ok((old_value, new_value))
+    }
+}
+
+/// A single number under each key, that is monotonically incremented by the
+/// given step size.
+///
+/// Internally, this is an abstraction over a [`Map`](crate::Map).
+pub struct Counters<'a, K, T, C = Borsh>
+where
+    C: Codec<T>,
+{
+    map: Map<'a, K, T, C>,
+    base: T,
+    step: T,
+}
+
+impl<'a, K, T, C> Counters<'a, K, T, C>
+where
+    C: Codec<T>,
+{
+    pub const fn new(storage_key: &'a str, base: T, step: T) -> Self {
+        Self {
+            map: Map::new(storage_key),
+            base,
+            step,
+        }
+    }
+}
+impl<'a, K, T, C> Counters<'a, K, T, C>
+where
+    K: Key + Copy,
+    T: Number + Copy,
+    C: Codec<T>,
+{
+    /// Load the current counter value under the given key.
+    pub fn current(&self, storage: &dyn Storage, key: K) -> StdResult<T> {
+        self.map
+            .may_load(storage, key)
+            .map(|maybe_value| maybe_value.unwrap_or(self.base))
+    }
+
+    /// Increment the value under the given key by the step size; return the
+    /// values before and after incrementing.
+    pub fn increment(&self, storage: &mut dyn Storage, key: K) -> StdResult<(T, T)> {
+        let old_value = self.current(storage, key)?;
+        let new_value = old_value.checked_add(self.step)?;
+
+        self.map.save(storage, key, &new_value)?;
 
         Ok((old_value, new_value))
     }


### PR DESCRIPTION
- Allow user to specify the starting value and step size for the counter.
- Return both the old and new value in the `Counter::increment` method.
- Add a `Counters` (plural) type which is a wrapper over a `Map`