### PR TITLE
UniqueIndex redone

### DIFF
--- a/crates/storage/src/codec.rs
+++ b/crates/storage/src/codec.rs
@@ -66,3 +66,16 @@ where
         from_json_slice(data)
     }
 }
+
+/// Represents raw bytes without encoding.
+pub struct Raw;
+
+impl Codec<Vec<u8>> for Raw {
+    fn encode(data: &Vec<u8>) -> StdResult<Vec<u8>> {
+        Ok(data.clone())
+    }
+
+    fn decode(data: &[u8]) -> StdResult<Vec<u8>> {
+        Ok(data.to_vec())
+    }
+}

--- a/crates/storage/src/codec.rs
+++ b/crates/storage/src/codec.rs
@@ -15,6 +15,8 @@ pub trait Codec<T> {
     fn decode(data: &[u8]) -> StdResult<T>;
 }
 
+// ----------------------------------- borsh -----------------------------------
+
 /// Represents the Borsh encoding scheme.
 pub struct Borsh;
 
@@ -31,6 +33,8 @@ where
     }
 }
 
+// ----------------------------------- proto -----------------------------------
+
 /// Represents the Protobuf encoding scheme.
 pub struct Proto;
 
@@ -46,6 +50,8 @@ where
         from_proto_slice(data)
     }
 }
+
+// -------------------------------- serde json ---------------------------------
 
 /// Represents the JSON encoding scheme.
 ///
@@ -66,6 +72,8 @@ where
         from_json_slice(data)
     }
 }
+
+// ------------------------------------ raw ------------------------------------
 
 /// Represents raw bytes without encoding.
 pub struct Raw;

--- a/crates/storage/src/index/map.rs
+++ b/crates/storage/src/index/map.rs
@@ -300,7 +300,7 @@ mod tests {
             "foo",
             "foo__name_surname",
         ),
-        id: UniqueIndex::new(|data| data.id, "foo__id"),
+        id: UniqueIndex::new(|_, data| data.id, "foo", "foo__id"),
     });
 
     #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
@@ -323,7 +323,7 @@ mod tests {
     struct FooIndexes<'a> {
         pub name: MultiIndex<'a, (u64, u64), String, Foo>,
         pub name_surname: MultiIndex<'a, (u64, u64), (String, String), Foo>,
-        pub id: UniqueIndex<'a, u32, Foo>,
+        pub id: UniqueIndex<'a, (u64, u64), u32, Foo>,
     }
 
     impl<'a> IndexList<(u64, u64), Foo> for FooIndexes<'a> {
@@ -357,7 +357,7 @@ mod tests {
 
         // Load a single data by the index.
         {
-            let val = FOOS.idx.id.load(&storage, 104).unwrap();
+            let val = FOOS.idx.id.load_value(&storage, 104).unwrap();
             assert_eq!(val, Foo::new("bar", "s_fooes", 104));
         }
 
@@ -372,7 +372,7 @@ mod tests {
             let val = FOOS
                 .idx
                 .id
-                .range(&storage, None, None, Order::Ascending)
+                .values(&storage, None, None, Order::Ascending)
                 .map(|val| val.unwrap())
                 .collect::<Vec<_>>();
 

--- a/crates/storage/src/index/multi.rs
+++ b/crates/storage/src/index/multi.rs
@@ -81,7 +81,7 @@ where
                 //
                 // If the indexed map works correctly, the data should always exist,
                 // so we can safely unwrap the `Option` here.
-                let v_raw = self.primary_map.load_raw(storage, pk_raw).unwrap();
+                let v_raw = self.primary_map.may_load_raw(storage, pk_raw).unwrap();
                 (ik_raw, pk_raw.to_vec(), v_raw)
             });
 
@@ -150,7 +150,7 @@ where
             .range_raw(storage, min, max, order)
             .map(|ik_pk_raw| {
                 let (_, pk_raw) = split_first_key(IK::KEY_ELEMS, &ik_pk_raw);
-                self.primary_map.load_raw(storage, pk_raw).unwrap()
+                self.primary_map.may_load_raw(storage, pk_raw).unwrap()
             });
 
         Box::new(iter)
@@ -168,7 +168,7 @@ where
             .range_raw(storage, min, max, order)
             .map(|ik_pk_raw| {
                 let (_, pk_raw) = split_first_key(IK::KEY_ELEMS, &ik_pk_raw);
-                let v_raw = self.primary_map.load_raw(storage, pk_raw).unwrap();
+                let v_raw = self.primary_map.may_load_raw(storage, pk_raw).unwrap();
                 C::decode(&v_raw)
             });
 

--- a/crates/storage/src/index/multi.rs
+++ b/crates/storage/src/index/multi.rs
@@ -81,7 +81,7 @@ where
                 //
                 // If the indexed map works correctly, the data should always exist,
                 // so we can safely unwrap the `Option` here.
-                let v_raw = self.primary_map.may_load_raw(storage, pk_raw).unwrap();
+                let v_raw = self.primary_map.load_raw(storage, pk_raw).unwrap();
                 (ik_raw, pk_raw.to_vec(), v_raw)
             });
 
@@ -150,7 +150,7 @@ where
             .range_raw(storage, min, max, order)
             .map(|ik_pk_raw| {
                 let (_, pk_raw) = split_first_key(IK::KEY_ELEMS, &ik_pk_raw);
-                self.primary_map.may_load_raw(storage, pk_raw).unwrap()
+                self.primary_map.load_raw(storage, pk_raw).unwrap()
             });
 
         Box::new(iter)
@@ -168,7 +168,7 @@ where
             .range_raw(storage, min, max, order)
             .map(|ik_pk_raw| {
                 let (_, pk_raw) = split_first_key(IK::KEY_ELEMS, &ik_pk_raw);
-                let v_raw = self.primary_map.may_load_raw(storage, pk_raw).unwrap();
+                let v_raw = self.primary_map.load_raw(storage, pk_raw).unwrap();
                 C::decode(&v_raw)
             });
 

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -85,7 +85,7 @@ where
             .index_map
             .range_raw(storage, min, max, order)
             .map(|(ik_raw, pk_raw)| {
-                let v_raw = self.primary_map.load_raw(storage, &pk_raw).unwrap();
+                let v_raw = self.primary_map.may_load_raw(storage, &pk_raw).unwrap();
                 (ik_raw, pk_raw, v_raw)
             });
 
@@ -151,7 +151,7 @@ where
             .index_map
             .range_raw(storage, min, max, order)
             .map(|(ik_raw, pk_raw)| {
-                let v_raw = self.primary_map.load_raw(storage, &pk_raw).unwrap();
+                let v_raw = self.primary_map.may_load_raw(storage, &pk_raw).unwrap();
                 (ik_raw, v_raw)
             });
 
@@ -174,7 +174,7 @@ where
             .range_raw(storage, min, max, order)
             .map(|(ik_raw, pk_raw)| {
                 let ik = IK::from_slice(&ik_raw)?;
-                let v_raw = self.primary_map.load_raw(storage, &pk_raw).unwrap();
+                let v_raw = self.primary_map.may_load_raw(storage, &pk_raw).unwrap();
                 let v = PC::decode(&v_raw)?;
                 Ok((ik, v))
             });

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -1,7 +1,6 @@
 use {
-    crate::{Borsh, Codec, Index, Key, Map},
-    grug_types::{StdError, StdResult, Storage},
-    std::ops::Deref,
+    crate::{Borsh, Bound, Codec, Index, Key, Map},
+    grug_types::{Order, StdError, StdResult, Storage},
 };
 
 /// An indexer that ensures that indexes are unique, meaning no two records in
@@ -13,65 +12,198 @@ use {
 ///
 /// - In the primary map: (pk_namespace, pk) => value
 /// - in the index map: (idx_namespace, ik) => value
-pub struct UniqueIndex<'a, IK, T, C = Borsh>
+pub struct UniqueIndex<'a, PK, IK, T, PC = Borsh, IC = Borsh>
 where
-    C: Codec<T>,
+    PK: Key + Clone,
+    IK: Key + Clone,
+    PC: Codec<T>,
+    IC: Codec<PK>,
 {
     /// A function that takes a piece of data, and return the index key it
     /// should be indexed at.
-    indexer: fn(&T) -> IK,
-    /// Data indexed by the index key.
-    idx_map: Map<'a, IK, T, C>,
+    indexer: fn(&PK, &T) -> IK,
+    /// Primary key by the index key.
+    index_map: Map<'a, IK, PK, IC>,
+    /// Data indexed by primary key.
+    primary_map: Map<'a, PK, T, PC>,
 }
 
-impl<'a, IK, T, C> UniqueIndex<'a, IK, T, C>
+impl<'a, PK, IK, T, PC, IC> UniqueIndex<'a, PK, IK, T, PC, IC>
 where
-    C: Codec<T>,
+    PK: Key + Clone,
+    IK: Key + Clone,
+    PC: Codec<T>,
+    IC: Codec<PK>,
 {
     /// Note: The developer must make sure that `idx_namespace` is not the same
     /// as the primary map namespace.
-    pub const fn new(indexer: fn(&T) -> IK, idx_namespace: &'static str) -> Self {
+    pub const fn new(
+        indexer: fn(&PK, &T) -> IK,
+        pk_namespace: &'static str,
+        idx_namespace: &'static str,
+    ) -> Self {
         UniqueIndex {
             indexer,
-            idx_map: Map::new(idx_namespace),
+            index_map: Map::new(idx_namespace),
+            primary_map: Map::new(pk_namespace),
         }
     }
-}
 
-// Since the `UniqueIndex` is essentially a wrapper of a `Map` (`self.idx_map`),
-// we let it dereference to the inner map. This way, users are able to directly
-// call methods on the inner map, such as `range`, `prefix`, etc.
-impl<'a, IK, T, C> Deref for UniqueIndex<'a, IK, T, C>
-where
-    C: Codec<T>,
-{
-    type Target = Map<'a, IK, T, C>;
+    /// Given an index value, load the corresponding key.
+    pub fn load_key(&self, storage: &dyn Storage, idx: IK) -> StdResult<PK> {
+        self.index_map.load(storage, idx)
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.idx_map
+    /// Given an index value, load the corresponding value.
+    pub fn load_value(&self, storage: &dyn Storage, idx: IK) -> StdResult<T> {
+        let pk = self.index_map.load(storage, idx)?;
+
+        self.primary_map.load(storage, pk)
+    }
+
+    /// Given an index value, load the corresponding primary key and value.
+    pub fn load(&self, storage: &dyn Storage, idx: IK) -> StdResult<(PK, T)> {
+        let pk = self.index_map.load(storage, idx)?;
+        let v = self.primary_map.load(storage, pk.clone())?;
+
+        Ok((pk, v))
+    }
+
+    /// Iterate all {index, primary key, value} tuples within a bound of indexes,
+    /// without deserialization.
+    pub fn range_raw<'b>(
+        &'b self,
+        storage: &'b dyn Storage,
+        min: Option<Bound<IK>>,
+        max: Option<Bound<IK>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>, Vec<u8>)> + 'b>
+    where
+        'a: 'b,
+    {
+        let iter = self
+            .index_map
+            .range_raw(storage, min, max, order)
+            .map(|(ik_raw, pk_raw)| {
+                let v_raw = self.primary_map.load_raw(storage, &pk_raw).unwrap();
+                (ik_raw, pk_raw, v_raw)
+            });
+
+        Box::new(iter)
+    }
+
+    /// Iterate all {index, primary key, value} tuples within a bound of indexes.
+    pub fn range<'b>(
+        &'b self,
+        storage: &'b dyn Storage,
+        min: Option<Bound<IK>>,
+        max: Option<Bound<IK>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<(IK::Output, PK, T)>> + 'b>
+    where
+        'a: 'b,
+    {
+        let iter = self.index_map.range(storage, min, max, order).map(|ik_pk| {
+            let (ik, pk) = ik_pk?;
+            let v = self.primary_map.load(storage, pk.clone())?;
+            Ok((ik, pk, v))
+        });
+
+        Box::new(iter)
+    }
+
+    /// Iterate all {index, primary key} tuples within a bound of indexes,
+    /// without deserialization.
+    pub fn keys_raw<'b>(
+        &self,
+        storage: &'b dyn Storage,
+        min: Option<Bound<IK>>,
+        max: Option<Bound<IK>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + 'b> {
+        self.index_map.range_raw(storage, min, max, order)
+    }
+
+    /// Iterate all {index, primary key} tuples within a bound of indexes.
+    pub fn keys<'b>(
+        &self,
+        storage: &'b dyn Storage,
+        min: Option<Bound<IK>>,
+        max: Option<Bound<IK>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<(IK::Output, PK)>> + 'b> {
+        self.index_map.range(storage, min, max, order)
+    }
+
+    /// Iterate all {index, value} tuples within a bound of indexes, without
+    /// deserialization.
+    pub fn values_raw<'b>(
+        &'b self,
+        storage: &'b dyn Storage,
+        min: Option<Bound<IK>>,
+        max: Option<Bound<IK>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + 'b>
+    where
+        'a: 'b,
+    {
+        let iter = self
+            .index_map
+            .range_raw(storage, min, max, order)
+            .map(|(ik_raw, pk_raw)| {
+                let v_raw = self.primary_map.load_raw(storage, &pk_raw).unwrap();
+                (ik_raw, v_raw)
+            });
+
+        Box::new(iter)
+    }
+
+    /// Iterate all {index, value} tuples within a bound of indexes.
+    pub fn values<'b>(
+        &'b self,
+        storage: &'b dyn Storage,
+        min: Option<Bound<IK>>,
+        max: Option<Bound<IK>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<(IK::Output, T)>> + 'b>
+    where
+        'a: 'b,
+    {
+        let iter = self
+            .index_map
+            .range_raw(storage, min, max, order)
+            .map(|(ik_raw, pk_raw)| {
+                let ik = IK::from_slice(&ik_raw)?;
+                let v_raw = self.primary_map.load_raw(storage, &pk_raw).unwrap();
+                let v = PC::decode(&v_raw)?;
+                Ok((ik, v))
+            });
+
+        Box::new(iter)
     }
 }
 
-impl<'a, PK, IK, T, C> Index<PK, T> for UniqueIndex<'a, IK, T, C>
+impl<'a, PK, IK, T, PC, IC> Index<PK, T> for UniqueIndex<'a, PK, IK, T, PC, IC>
 where
+    PK: Key + Clone,
     IK: Key + Clone,
-    C: Codec<T>,
-    T: Clone,
+    PC: Codec<T>,
+    IC: Codec<PK>,
 {
-    fn save(&self, storage: &mut dyn Storage, _pk: PK, data: &T) -> StdResult<()> {
-        let idx = (self.indexer)(data);
+    fn save(&self, storage: &mut dyn Storage, pk: PK, data: &T) -> StdResult<()> {
+        let idx = (self.indexer)(&pk, data);
 
         // Ensure that indexes are unique.
-        if self.idx_map.has(storage, idx.clone()) {
+        if self.index_map.has(storage, idx.clone()) {
             // TODO: create a `StdError::DuplicateData` for this?
             return Err(StdError::generic_err("Violates unique constraint on index"));
         }
 
-        self.idx_map.save(storage, idx, data)
+        self.index_map.save(storage, idx, &pk)
     }
 
-    fn remove(&self, storage: &mut dyn Storage, _pk: PK, old_data: &T) {
-        let idx = (self.indexer)(old_data);
-        self.idx_map.remove(storage, idx);
+    fn remove(&self, storage: &mut dyn Storage, pk: PK, old_data: &T) {
+        let idx = (self.indexer)(&pk, old_data);
+        self.index_map.remove(storage, idx);
     }
 }

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -195,8 +195,7 @@ where
 
         // Ensure that indexes are unique.
         if self.index_map.has(storage, idx.clone()) {
-            // TODO: create a `StdError::DuplicateData` for this?
-            return Err(StdError::generic_err("Violates unique constraint on index"));
+            return Err(StdError::duplicate_data::<IK>(&idx.joined_key()));
         }
 
         self.index_map.save(storage, idx, &pk)

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -18,12 +18,12 @@ where
     IK: Key + Clone,
     C: Codec<T>,
 {
-    /// A function that takes a piece of data, and return the index key it
+    /// A function that takes a key-value pair, and return the index key it
     /// should be indexed at.
     indexer: fn(&PK, &T) -> IK,
-    /// Primary key by the _raw_ index key.
+    // Index => _raw_ primary key
     index_map: Map<'a, IK, Vec<u8>, Raw>,
-    /// Data indexed by primary key.
+    // Primary key => data
     primary_map: Map<'a, PK, T, C>,
 }
 

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -54,6 +54,9 @@ pub enum StdError {
     #[error("data not found! type: {ty}, storage key: {key}")]
     DataNotFound { ty: &'static str, key: String },
 
+    #[error("duplicate data found! type: {ty}, data: {data}")]
+    DataDuplicate { ty: &'static str, data: String },
+
     #[error("cannot find iterator with ID {iterator_id}")]
     IteratorNotFound { iterator_id: i32 },
 
@@ -169,6 +172,13 @@ impl StdError {
         Self::DataNotFound {
             ty: type_name::<T>(),
             key: BASE64.encode(key),
+        }
+    }
+
+    pub fn duplicate_data<T>(data: &[u8]) -> Self {
+        Self::DataDuplicate {
+            ty: type_name::<T>(),
+            data: BASE64.encode(data),
         }
     }
 

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -55,7 +55,7 @@ pub enum StdError {
     DataNotFound { ty: &'static str, key: String },
 
     #[error("duplicate data found! type: {ty}, data: {data}")]
-    DataDuplicate { ty: &'static str, data: String },
+    DuplicateData { ty: &'static str, data: String },
 
     #[error("cannot find iterator with ID {iterator_id}")]
     IteratorNotFound { iterator_id: i32 },
@@ -176,7 +176,7 @@ impl StdError {
     }
 
     pub fn duplicate_data<T>(data: &[u8]) -> Self {
-        Self::DataDuplicate {
+        Self::DuplicateData {
             ty: type_name::<T>(),
             data: BASE64.encode(data),
         }


### PR DESCRIPTION
- `UniqueIndex::index_map` now stores a mapping of IK => PK (previously it stores IK => T). This allows us to give an IK and find the corresponding PK (previously not possible).
- The indexer function of `UniqueIndex` now also takes the PK (previously only takes T).
- Adds an error type `StdError::DuplicateData`