### PR TITLE
refactor: merge impl_next! macro into generate_uint!

### DIFF
--- a/crates/types/src/macros.rs
+++ b/crates/types/src/macros.rs
@@ -139,6 +139,7 @@ macro_rules! generate_uint {
         inner_type = $inner:ty,
         from_int = [$($from:ty),*],
         from_std = [$($from_std:ty),*],
+        next = [$($next:ty)?],
         doc = $doc:literal,
     ) => {
         #[doc = $doc]
@@ -218,6 +219,13 @@ macro_rules! generate_uint {
                value.number()
             }
         }
+
+        $(
+        // --- Impl NextNumbr ---
+        impl NextNumber for $name {
+            type Next = $next;
+        }
+        )?
     };
 }
 
@@ -721,16 +729,6 @@ macro_rules! impl_integer_number {
             fn checked_ilog10(self) -> StdResult<u32> {
                 self.checked_ilog10().ok_or_else(|| StdError::zero_log())
             }
-        }
-    };
-}
-
-#[macro_export]
-#[doc(hidden)]
-macro_rules! impl_next {
-    ($t:ty, $next:ty) => {
-        impl NextNumber for $t {
-            type Next = $next;
         }
     };
 }

--- a/crates/types/src/math/uint.rs
+++ b/crates/types/src/math/uint.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         forward_ref_binop_typed, forward_ref_op_assign_typed, generate_uint,
-        impl_all_ops_and_assign, impl_assign_integer, impl_assign_number, impl_integer, impl_next,
+        impl_all_ops_and_assign, impl_assign_integer, impl_assign_number, impl_integer,
         impl_number, Bytable, Fraction, Inner, Integer, MultiplyFraction, MultiplyRatio,
         NextNumber, Number, NumberConst, Sign, StdError, StdResult,
     },
@@ -402,6 +402,7 @@ generate_uint!(
     inner_type = u64,
     from_int = [],
     from_std = [u32, u16, u8],
+    next = [Uint128],
     doc = "64-bit unsigned integer.",
 );
 
@@ -410,6 +411,7 @@ generate_uint!(
     inner_type = u128,
     from_int = [Uint64],
     from_std = [u32, u16, u8],
+    next = [Uint256],
     doc = "128-bit unsigned integer.",
 );
 
@@ -418,6 +420,7 @@ generate_uint!(
     inner_type = U256,
     from_int = [Uint64, Uint128],
     from_std = [u32, u16, u8],
+    next = [Uint512],
     doc = "256-bit unsigned integer.",
 );
 
@@ -426,13 +429,9 @@ generate_uint!(
     inner_type = U512,
     from_int = [Uint256, Uint64, Uint128],
     from_std = [u32, u16, u8],
+    next = [],
     doc = "512-bit unsigned integer.",
 );
-
-// TODO: can we merge these into `generate_uint`?
-impl_next!(Uint64, Uint128);
-impl_next!(Uint128, Uint256);
-impl_next!(Uint256, Uint512);
 
 // ----------------------------------- tests -----------------------------------
 


### PR DESCRIPTION
This PR merge the two macros `impl_next!` & `generate_uint!` into `generate_uint!`