### PR TITLE
feat: `#[derive(grug::QueryRequest)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,6 +1793,7 @@ dependencies = [
  "grug-bank",
  "grug-crypto",
  "grug-db-memory",
+ "grug-macros",
  "grug-storage",
  "grug-taxman",
  "grug-types",

--- a/contracts/bank/src/types.rs
+++ b/contracts/bank/src/types.rs
@@ -1,5 +1,5 @@
 use {
-    grug_types::{Addr, Coins, Uint256},
+    grug_types::{Addr, Coins, QueryRequest, Uint256},
     serde::{Deserialize, Serialize},
     std::collections::BTreeMap,
 };
@@ -39,10 +39,31 @@ pub enum ExecuteMsg {
 #[serde(rename = "snake_case")]
 pub enum QueryMsg {
     /// Enumerate all holders of a given token and their balances.
-    /// Returns: `BTreeMap<Addr, Uint128>`.
+    /// Returns: `BTreeMap<Addr, Uint256>`.
     Holders {
         denom: String,
         start_after: Option<Addr>,
         limit: Option<u32>,
     },
+}
+
+pub struct QueryHoldersRequest {
+    pub denom: String,
+    pub start_after: Option<Addr>,
+    pub limit: Option<u32>,
+}
+
+impl From<QueryHoldersRequest> for QueryMsg {
+    fn from(req: QueryHoldersRequest) -> Self {
+        QueryMsg::Holders {
+            denom: req.denom,
+            start_after: req.start_after,
+            limit: req.limit,
+        }
+    }
+}
+
+impl QueryRequest for QueryHoldersRequest {
+    type Message = QueryMsg;
+    type Response = BTreeMap<Addr, Uint256>;
 }

--- a/contracts/tester/src/execute.rs
+++ b/contracts/tester/src/execute.rs
@@ -1,5 +1,5 @@
 use {
-    crate::QueryMsg,
+    crate::QueryForceWriteRequest,
     grug::{MutableCtx, Number, NumberConst, Response, StdResult, Uint128},
 };
 
@@ -12,7 +12,7 @@ pub fn infinite_loop() -> StdResult<Response> {
 
 pub fn force_write_on_query(ctx: MutableCtx, key: String, value: String) -> StdResult<Response> {
     ctx.querier
-        .query_wasm_smart(ctx.contract, &QueryMsg::ForceWrite { key, value })?;
+        .query_wasm_smart(ctx.contract, QueryForceWriteRequest { key, value })?;
 
     Ok(Response::new())
 }

--- a/contracts/tester/src/types.rs
+++ b/contracts/tester/src/types.rs
@@ -16,7 +16,7 @@ pub enum ExecuteMsg {
 }
 
 #[grug::derive(serde)]
-#[derive(grug::Query)]
+#[derive(grug::QueryRequest)]
 pub enum QueryMsg {
     /// Run a loop of the given number of iterations. Within each iteration, a
     /// set of math operations (addition, subtraction, multiplication, division)

--- a/contracts/tester/src/types.rs
+++ b/contracts/tester/src/types.rs
@@ -16,6 +16,7 @@ pub enum ExecuteMsg {
 }
 
 #[grug::derive(serde)]
+#[derive(grug::Query)]
 pub enum QueryMsg {
     /// Run a loop of the given number of iterations. Within each iteration, a
     /// set of math operations (addition, subtraction, multiplication, division)
@@ -24,6 +25,7 @@ pub enum QueryMsg {
     /// This is used for deducing the relation between Wasmer gas metering
     /// points and CPU time (i.e. how many gas points roughly correspond to one
     /// second of run time).
+    #[returns(Empty)]
     Loop { iterations: u64 },
     /// Attempt to write a key-value pair to the contract storage.
     ///
@@ -34,5 +36,6 @@ pub enum QueryMsg {
     /// However, a malicious contract can attempt to directly call the `db_write`,
     /// `db_remove`, or `db_remove_range` FFI import methods directly. We need
     /// to test whether the VM can properly reject this behavior.
+    #[returns(Empty)]
     ForceWrite { key: String, value: String },
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,6 +1,7 @@
 mod derive;
 mod export;
 mod index_list;
+mod query;
 
 use proc_macro::TokenStream;
 
@@ -47,4 +48,9 @@ pub fn export(_attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn index_list(attr: TokenStream, input: TokenStream) -> TokenStream {
     index_list::process(attr, input)
+}
+
+#[proc_macro_derive(Query, attributes(returns, query_path_override))]
+pub fn derive_query(input: TokenStream) -> TokenStream {
+    query::process(input)
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -50,7 +50,7 @@ pub fn index_list(attr: TokenStream, input: TokenStream) -> TokenStream {
     index_list::process(attr, input)
 }
 
-#[proc_macro_derive(Query, attributes(returns))]
+#[proc_macro_derive(QueryRequest, attributes(returns))]
 pub fn derive_query(input: TokenStream) -> TokenStream {
     query::process(input)
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -50,7 +50,7 @@ pub fn index_list(attr: TokenStream, input: TokenStream) -> TokenStream {
     index_list::process(attr, input)
 }
 
-#[proc_macro_derive(Query, attributes(returns, query_path_override))]
+#[proc_macro_derive(Query, attributes(returns))]
 pub fn derive_query(input: TokenStream) -> TokenStream {
     query::process(input)
 }

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -1,13 +1,26 @@
 use {
     core::panic,
     proc_macro::TokenStream,
-    quote::{quote, ToTokens},
-    syn::{parse_macro_input, Data, DeriveInput, Ident, Type},
+    quote::quote,
+    syn::{parse_macro_input, Data, DeriveInput, Fields, Ident, Type},
 };
 
+/// Throughout the function, we will use comments to illustrate how it works,
+/// based on the following example:
+///
+/// ```rust
+/// #[derive(grug::Query)]
+/// enum QueryMsg {
+///     #[returns(String)]
+///     Foo { bar: u64 },
+///     #[returns(Buzz)]
+///     Fuzz(i128),
+/// }
+/// ```
 pub fn process(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
+    // E.g. `QueryMsg`
     let name = input.ident;
 
     let Data::Enum(data) = input.data else {
@@ -19,7 +32,17 @@ pub fn process(input: TokenStream) -> TokenStream {
     let mut impl_trait_response = Vec::new();
     let mut impl_as_query_msg = Vec::new();
 
+    // Iterate through the variants of the query message.
     for variant in data.variants.into_iter() {
+        // E.g. `Foo`.
+        let variant_name = &variant.ident;
+
+        // Name of the query request for this variant, which we will generate.
+        // E.g. `QueryFooRequest`.
+        let request_name = Ident::new(&format!("Query{variant_name}Request"), variant.ident.span());
+
+        // Return type for this variant specified in the `#[return]` attribute.
+        // E.g. for `Foo`, this would be `String`; for `Fuzz`, this would be `Buzz`.
         let return_type: Type = variant
             .attrs
             .iter()
@@ -28,18 +51,17 @@ pub fn process(input: TokenStream) -> TokenStream {
             .parse_args()
             .expect("only one type supported");
 
-        let variant_name = &variant.ident;
-
-        let request = match variant.fields {
-            syn::Fields::Named(variant_ty) => {
-                let struct_name =
-                    Ident::new(&format!("{variant_name}Request"), variant.ident.span());
-
+        // Iterate through fields in the query message variant.
+        // In the example, there is one variant: `bar`.
+        match variant.fields {
+            Fields::Named(variant_ty) => {
                 let mut fields_struct_definition = Vec::new();
                 let mut fields_struct_into = Vec::new();
 
                 for field in variant_ty.named {
+                    // E.g. `"bar"`
                     let field_name = &field.ident;
+                    // E.g. `u64`
                     let field_type = &field.ty;
 
                     fields_struct_definition.push(quote! {
@@ -51,49 +73,78 @@ pub fn process(input: TokenStream) -> TokenStream {
                     });
                 }
 
-                // Generate the struct definition
+                // Generate the query request struct definition, e.g.
+                //
+                // ```rust
+                // pub struct QueryFooRequest {
+                //     pub bar: u64,
+                // }
+                // ```
                 generated_structs.push(quote! {
-                    pub struct #struct_name {
+                    pub struct #request_name {
                         #(#fields_struct_definition)*
                     }
                 });
 
+                // E.g.
+                //
+                // ```rust
+                // impl From<QueryFooRequest> for QueryMsg {
+                //     fn from(val: QueryFooRequest) -> Self {
+                //         Self::Foo {
+                //             bar: val.bar,
+                //         }
+                //    }
+                // }
+                // ```
                 impl_req_to_enum.push(quote! {
-                    impl From<#struct_name> for #name {
-                        fn from(val: #struct_name) -> Self {
+                    impl From<#request_name> for #name {
+                        fn from(val: #request_name) -> Self {
                             Self::#variant_name {
                                 #(#fields_struct_into)*
                             }
                         }
                     }
                 });
-
-                struct_name.to_token_stream()
             },
-            syn::Fields::Unnamed(variant_ty) => {
-                let unamed = variant_ty.unnamed.to_token_stream();
+            Fields::Unnamed(variant_ty) => {
+                // Generate the query request struct definition, e.g.
+                //
+                // ```rust
+                // pub struct QueryFuzzRequest(i128);
+                // ```
+                generated_structs.push(quote! {
+                    pub struct #request_name(#variant_ty);
+                });
 
+                // E.g.
+                //
+                // ```rust
+                // impl From<QueryFuzzRequest> for QueryMsg {
+                //     fn from(val: QueryFuzzRequest) -> Self {
+                //         Self::Fuzz(val.0)
+                //     }
+                // }
+                // ```
                 impl_req_to_enum.push(quote! {
-                    impl From<#unamed> for #name {
-                        fn from(val: #unamed) -> Self {
-                            Self::#variant_name(val)
+                    impl From<#request_name> for #name {
+                        fn from(val: #request_name) -> Self {
+                            Self::#variant_name(val.0)
                         }
                     }
                 });
-
-                unamed
             },
-            syn::Fields::Unit => panic!("query message cannot contain unit variants"),
+            Fields::Unit => panic!("query message cannot contain unit variants"),
         };
 
         impl_trait_response.push(quote! {
-            impl ::grug::QueryResponseType for #request {
+            impl ::grug::QueryResponseType for #request_name {
                 type Response = #return_type;
             }
         });
 
         impl_as_query_msg.push(quote! {
-            impl ::grug::AsQueryMsg for #request {
+            impl ::grug::AsQueryMsg for #request_name {
                 type QueryMsg = #name;
             }
         });

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -1,7 +1,7 @@
 use {
     core::panic,
     proc_macro::TokenStream,
-    quote::quote,
+    quote::{quote, ToTokens},
     syn::{parse_macro_input, Data, DeriveInput, Fields, Ident, Type},
 };
 
@@ -33,7 +33,7 @@ pub fn process(input: TokenStream) -> TokenStream {
     let mut impl_as_query_msg = Vec::new();
 
     // Iterate through the variants of the query message.
-    for variant in data.variants.into_iter() {
+    for variant in data.variants {
         // E.g. `Foo`.
         let variant_name = &variant.ident;
 
@@ -108,13 +108,15 @@ pub fn process(input: TokenStream) -> TokenStream {
                 });
             },
             Fields::Unnamed(variant_ty) => {
+                let unnamed = variant_ty.unnamed.into_token_stream();
+
                 // Generate the query request struct definition, e.g.
                 //
                 // ```rust
                 // pub struct QueryFuzzRequest(i128);
                 // ```
                 generated_structs.push(quote! {
-                    pub struct #request_name(pub #variant_ty);
+                    pub struct #request_name(pub #unnamed);
                 });
 
                 // E.g.

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -30,9 +30,8 @@ pub fn process(input: TokenStream) -> TokenStream {
     };
 
     let mut generated_structs = Vec::new();
-    let mut impl_req_to_enum = Vec::new();
-    let mut impl_trait_response = Vec::new();
-    let mut impl_as_query_msg = Vec::new();
+    let mut impl_into_msg = Vec::new();
+    let mut impl_query_request = Vec::new();
 
     // Iterate through the variants of the query message.
     for variant in data.variants {
@@ -98,7 +97,7 @@ pub fn process(input: TokenStream) -> TokenStream {
                 //    }
                 // }
                 // ```
-                impl_req_to_enum.push(quote! {
+                impl_into_msg.push(quote! {
                     impl From<#request_name> for #name {
                         fn from(val: #request_name) -> Self {
                             Self::#variant_name {
@@ -129,7 +128,7 @@ pub fn process(input: TokenStream) -> TokenStream {
                 //     }
                 // }
                 // ```
-                impl_req_to_enum.push(quote! {
+                impl_into_msg.push(quote! {
                     impl From<#request_name> for #name {
                         fn from(val: #request_name) -> Self {
                             Self::#variant_name(val.0)
@@ -156,7 +155,7 @@ pub fn process(input: TokenStream) -> TokenStream {
                 //     }
                 // }
                 // ```
-                impl_req_to_enum.push(quote! {
+                impl_into_msg.push(quote! {
                     impl From<#request_name> for #name {
                         fn from(_val: #request_name) -> Self {
                             Self::#variant_name
@@ -166,24 +165,18 @@ pub fn process(input: TokenStream) -> TokenStream {
             },
         };
 
-        impl_trait_response.push(quote! {
-            impl ::grug::QueryResponseType for #request_name {
+        impl_query_request.push(quote! {
+            impl ::grug::QueryRequest for #request_name {
+                type Message = #name;
                 type Response = #return_type;
-            }
-        });
-
-        impl_as_query_msg.push(quote! {
-            impl ::grug::AsQueryMsg for #request_name {
-                type QueryMsg = #name;
             }
         });
     }
 
     quote! {
         #(#generated_structs)*
-        #(#impl_req_to_enum)*
-        #(#impl_trait_response)*
-        #(#impl_as_query_msg)*
+        #(#impl_into_msg)*
+        #(#impl_query_request)*
     }
     .into()
 }

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -11,15 +11,12 @@ pub fn process(input: TokenStream) -> TokenStream {
     let name = input.ident;
 
     let Data::Enum(data) = input.data else {
-        panic!("only Enums are supported")
+        panic!("query message must be an enum")
     };
 
     let mut generated_structs = Vec::new();
-
     let mut impl_req_to_enum = Vec::new();
-
     let mut impl_trait_response = Vec::new();
-
     let mut impl_as_query_msg = Vec::new();
 
     for variant in data.variants.into_iter() {
@@ -55,13 +52,11 @@ pub fn process(input: TokenStream) -> TokenStream {
                 }
 
                 // Generate the struct definition
-                let struct_def = quote! {
+                generated_structs.push(quote! {
                     pub struct #struct_name {
                         #(#fields_struct_definition)*
                     }
-                };
-
-                generated_structs.push(struct_def);
+                });
 
                 impl_req_to_enum.push(quote! {
                     impl From<#struct_name> for #name {
@@ -85,9 +80,10 @@ pub fn process(input: TokenStream) -> TokenStream {
                         }
                     }
                 });
+
                 unamed
             },
-            syn::Fields::Unit => panic!("Unit variants are not supported"),
+            syn::Fields::Unit => panic!("query message cannot contain unit variants"),
         };
 
         impl_trait_response.push(quote! {

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -14,16 +14,6 @@ pub fn process(input: TokenStream) -> TokenStream {
         panic!("only Enums are supported")
     };
 
-    let path = input
-        .attrs
-        .iter()
-        .find(|attr| attr.path().get_ident().unwrap() == "query_path_override")
-        .map(|attr| {
-            attr.parse_args::<proc_macro2::TokenStream>()
-                .expect("query_path_override must be a valid path")
-        })
-        .unwrap_or(quote! { ::grug });
-
     let mut generated_structs = Vec::new();
 
     let mut impl_req_to_enum = Vec::new();
@@ -101,13 +91,13 @@ pub fn process(input: TokenStream) -> TokenStream {
         };
 
         impl_trait_response.push(quote! {
-            impl #path::QueryResponseType for #request {
+            impl ::grug::QueryResponseType for #request {
                 type Response = #return_type;
             }
         });
 
         impl_as_query_msg.push(quote! {
-            impl #path::AsQueryMsg for #request {
+            impl ::grug::AsQueryMsg for #request {
                 type QueryMsg = #name;
             }
         });

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -8,8 +8,8 @@ use {
 /// Throughout the function, we will use comments to illustrate how it works,
 /// based on the following example:
 ///
-/// ```rust
-/// #[derive(grug::Query)]
+/// ```rust ignore
+/// #[derive(grug::QueryRequest)]
 /// enum QueryMsg {
 ///     #[returns(String)]
 ///     Foo { bar: u64 },

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -114,7 +114,7 @@ pub fn process(input: TokenStream) -> TokenStream {
                 // pub struct QueryFuzzRequest(i128);
                 // ```
                 generated_structs.push(quote! {
-                    pub struct #request_name(#variant_ty);
+                    pub struct #request_name(pub #variant_ty);
                 });
 
                 // E.g.

--- a/crates/macros/src/query.rs
+++ b/crates/macros/src/query.rs
@@ -1,0 +1,123 @@
+use {
+    core::panic,
+    proc_macro::TokenStream,
+    quote::{quote, ToTokens},
+    syn::{parse_macro_input, Data, DeriveInput, Ident, Type},
+};
+
+pub fn process(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+
+    let Data::Enum(data) = input.data else {
+        panic!("only Enums are supported")
+    };
+
+    let path = input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().get_ident().unwrap() == "query_path_override")
+        .map(|attr| {
+            attr.parse_args::<proc_macro2::TokenStream>()
+                .expect("query_path_override must be a valid path")
+        })
+        .unwrap_or(quote! { ::grug });
+
+    let mut generated_structs = Vec::new();
+
+    let mut impl_req_to_enum = Vec::new();
+
+    let mut impl_trait_response = Vec::new();
+
+    let mut impl_as_query_msg = Vec::new();
+
+    for variant in data.variants.into_iter() {
+        let return_type: Type = variant
+            .attrs
+            .iter()
+            .find(|attr| attr.path().get_ident().unwrap() == "returns")
+            .expect("returns attribute missing")
+            .parse_args()
+            .expect("only one type supported");
+
+        let variant_name = &variant.ident;
+
+        let request = match variant.fields {
+            syn::Fields::Named(variant_ty) => {
+                let struct_name =
+                    Ident::new(&format!("{variant_name}Request"), variant.ident.span());
+
+                let mut fields_struct_definition = Vec::new();
+                let mut fields_struct_into = Vec::new();
+
+                for field in variant_ty.named {
+                    let field_name = &field.ident;
+                    let field_type = &field.ty;
+
+                    fields_struct_definition.push(quote! {
+                        pub #field_name: #field_type,
+                    });
+
+                    fields_struct_into.push(quote! {
+                        #field_name: val.#field_name,
+                    });
+                }
+
+                // Generate the struct definition
+                let struct_def = quote! {
+                    pub struct #struct_name {
+                        #(#fields_struct_definition)*
+                    }
+                };
+
+                generated_structs.push(struct_def);
+
+                impl_req_to_enum.push(quote! {
+                    impl From<#struct_name> for #name {
+                        fn from(val: #struct_name) -> Self {
+                            Self::#variant_name {
+                                #(#fields_struct_into)*
+                            }
+                        }
+                    }
+                });
+
+                struct_name.to_token_stream()
+            },
+            syn::Fields::Unnamed(variant_ty) => {
+                let unamed = variant_ty.unnamed.to_token_stream();
+
+                impl_req_to_enum.push(quote! {
+                    impl From<#unamed> for #name {
+                        fn from(val: #unamed) -> Self {
+                            Self::#variant_name(val)
+                        }
+                    }
+                });
+                unamed
+            },
+            syn::Fields::Unit => panic!("Unit variants are not supported"),
+        };
+
+        impl_trait_response.push(quote! {
+            impl #path::QueryResponseType for #request {
+                type Response = #return_type;
+            }
+        });
+
+        impl_as_query_msg.push(quote! {
+            impl #path::AsQueryMsg for #request {
+                type QueryMsg = #name;
+            }
+        });
+    }
+
+    quote! {
+        #(#generated_structs)*
+        #(#impl_req_to_enum)*
+        #(#impl_trait_response)*
+        #(#impl_as_query_msg)*
+    }
+    .into()
+}

--- a/crates/std/tests/queries.rs
+++ b/crates/std/tests/queries.rs
@@ -69,16 +69,16 @@ fn query_super_smart() {
     // Here, the compiler should be able to infer the type of the response as
     // `String` based on the request type `QueryFooRequest`.
     suite
-        .query_wasm_super_smart(contract, QueryFooRequest { bar: 12345 })
+        .query_wasm_smart(contract, QueryFooRequest { bar: 12345 })
         .should_succeed_and_equal(12345.to_string());
 
     // Similarly, for unnamed variant `Fuzz`.
     suite
-        .query_wasm_super_smart(contract, QueryFuzzRequest(123))
+        .query_wasm_smart(contract, QueryFuzzRequest(123))
         .should_succeed_and_equal(Addr::mock(123));
 
     // Similarly, for unit variant `Buzz`.
     suite
-        .query_wasm_super_smart(contract, QueryBuzzRequest)
+        .query_wasm_smart(contract, QueryBuzzRequest)
         .should_succeed_and_equal(Hash256::from_array([1; 32]));
 }

--- a/crates/std/tests/queries.rs
+++ b/crates/std/tests/queries.rs
@@ -1,0 +1,128 @@
+use {
+    grug::{Coins, ContractBuilder, Empty, NonZero, TestBuilder},
+    super_smart_querier::{AskConfigRequest, ConfigHost, QueryMsgClient},
+};
+
+mod super_smart_querier {
+    use grug::{
+        to_json_value, Addr, Empty, ImmutableCtx, Item, Json, MutableCtx, Response, StdResult,
+        Uint128,
+    };
+
+    const CONFIG: Item<ConfigHost> = Item::new("c");
+
+    #[grug::derive(serde, borsh)]
+    pub struct ConfigHost {
+        pub owner: String,
+        pub balance: Uint128,
+    }
+
+    #[grug::derive(serde)]
+    #[derive(grug::Query)]
+    pub enum QueryMsgHost {
+        #[returns(ConfigHost)]
+        Config {},
+    }
+
+    pub fn instantiate_host(ctx: MutableCtx, config: ConfigHost) -> StdResult<Response> {
+        CONFIG.save(ctx.storage, &config)?;
+
+        Ok(Response::new())
+    }
+
+    pub fn query_host(ctx: ImmutableCtx, msg: QueryMsgHost) -> StdResult<Json> {
+        match msg {
+            QueryMsgHost::Config {} => to_json_value(&CONFIG.load(ctx.storage)?),
+        }
+    }
+
+    // ---- Client ----
+    #[grug::derive(serde)]
+    #[derive(grug::Query)]
+    pub enum QueryMsgClient {
+        #[returns(ConfigHost)]
+        AskConfig { contract: Addr },
+    }
+
+    pub fn instantiate_client(_: MutableCtx, _: Empty) -> StdResult<Response> {
+        Ok(Response::new())
+    }
+
+    pub fn query_client(ctx: ImmutableCtx, msg: QueryMsgClient) -> StdResult<Json> {
+        match msg {
+            QueryMsgClient::AskConfig { contract } => {
+                let request = ConfigRequest {};
+                let response = ctx.querier.query_wasm_super_smart(contract, request)?;
+
+                Ok(to_json_value(&response)?)
+            },
+        }
+    }
+}
+
+#[test]
+fn query_super_smart() {
+    let (mut suite, accounts) = TestBuilder::new()
+        .add_account("larry", Coins::one("uusdc", NonZero::new(123_u128)))
+        .unwrap()
+        .set_chain_id("kebab")
+        .set_owner("larry")
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let host_contract = ContractBuilder::new(Box::new(super_smart_querier::instantiate_host))
+        .with_query(Box::new(super_smart_querier::query_host))
+        .build();
+
+    let client_contract = ContractBuilder::new(Box::new(super_smart_querier::instantiate_client))
+        .with_query(Box::new(super_smart_querier::query_client))
+        .build();
+
+    // If the contract successfully deploys, the multi query must have worked.
+    let (_, host_contract) = suite
+        .upload_and_instantiate(
+            &accounts["larry"],
+            host_contract,
+            "host_contract",
+            &ConfigHost {
+                owner: "rhaki".to_string(),
+                balance: 123_u128.into(),
+            },
+            Coins::new(),
+        )
+        .unwrap();
+
+    let (_, client_contract) = suite
+        .upload_and_instantiate(
+            &accounts["larry"],
+            client_contract,
+            "client_contract",
+            &Empty {},
+            Coins::new(),
+        )
+        .unwrap();
+
+    // Standard query_wasm_smart on suite
+    {
+        let result: ConfigHost = suite
+            .query_wasm_smart(client_contract, &QueryMsgClient::AskConfig {
+                contract: host_contract,
+            })
+            .should_succeed();
+
+        assert_eq!(result.owner, "rhaki");
+        assert_eq!(result.balance, 123_u128.into());
+    }
+
+    {
+        let result = suite
+            .query_wasm_super_smart(client_contract, AskConfigRequest {
+                contract: host_contract,
+            })
+            .should_succeed();
+
+        assert_eq!(result.owner, "rhaki");
+        assert_eq!(result.balance, 123_u128.into());
+    }
+}

--- a/crates/std/tests/queries.rs
+++ b/crates/std/tests/queries.rs
@@ -9,7 +9,7 @@ mod super_smart_querier {
     };
 
     #[grug::derive(serde)]
-    #[derive(grug::Query)]
+    #[derive(grug::QueryRequest)]
     pub enum QueryMsg {
         #[returns(String)]
         Foo { bar: u64 },

--- a/crates/std/tests/queries.rs
+++ b/crates/std/tests/queries.rs
@@ -1,6 +1,6 @@
 use {
     grug::{Coins, ContractBuilder, NonZero, TestBuilder, Uint128},
-    super_smart_querier::{Data, DataRequest},
+    super_smart_querier::{Data, QueryDataRequest},
 };
 
 mod super_smart_querier {
@@ -68,7 +68,7 @@ fn query_super_smart() {
     // Here, the compiler should be able to infer the type of the response as
     // `Data` based on the request type `DataRequest`.
     let res = suite
-        .query_wasm_super_smart(contract, DataRequest {})
+        .query_wasm_super_smart(contract, QueryDataRequest {})
         .should_succeed();
 
     assert_eq!(res.foo, "rhaki");

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -26,6 +26,7 @@ tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-borsh        = { workspace = true, features = ["derive", "de_strict_order"] }
-grug-storage = { path = "../storage" }
-test-case    = { workspace = true }
+borsh         = { workspace = true, features = ["derive", "de_strict_order"] }
+grug-macros   = { path = "../macros" }
+grug-storage  = { path = "../storage" }
+test-case     = { workspace = true }

--- a/crates/testing/src/suite.rs
+++ b/crates/testing/src/suite.rs
@@ -462,30 +462,7 @@ where
             .into()
     }
 
-    pub fn query_wasm_smart<M, R>(&self, contract: Addr, msg: &M) -> GenericResult<R>
-    where
-        M: Serialize,
-        R: DeserializeOwned,
-    {
-        (|| -> AppResult<_> {
-            let msg_raw = to_json_value(msg)?;
-            let res_raw = self
-                .app
-                .do_query_app(
-                    Query::WasmSmart {
-                        contract,
-                        msg: msg_raw,
-                    },
-                    0, // zero means to use the latest height
-                    false,
-                )?
-                .as_wasm_smart();
-            Ok(from_json_value(res_raw)?)
-        })()
-        .into()
-    }
-
-    pub fn query_wasm_super_smart<R>(&self, contract: Addr, req: R) -> GenericResult<R::Response>
+    pub fn query_wasm_smart<R>(&self, contract: Addr, req: R) -> GenericResult<R::Response>
     where
         R: QueryRequest,
         R::Message: Serialize,

--- a/crates/testing/src/suite.rs
+++ b/crates/testing/src/suite.rs
@@ -5,10 +5,10 @@ use {
     grug_crypto::sha2_256,
     grug_db_memory::MemDb,
     grug_types::{
-        from_json_value, to_json_value, Account, Addr, AsQueryMsg, Binary, BlockInfo, BlockOutcome,
-        Coins, ConfigUpdates, Duration, GenericResult, GenesisState, Hash256, InfoResponse, Json,
-        Message, NumberConst, Op, Outcome, Query, QueryResponseType, StdError, Tx, TxOutcome,
-        Uint256, Uint64, UnsignedTx,
+        from_json_value, to_json_value, Account, Addr, Binary, BlockInfo, BlockOutcome, Coins,
+        ConfigUpdates, Duration, GenericResult, GenesisState, Hash256, InfoResponse, Json, Message,
+        NumberConst, Op, Outcome, Query, QueryRequest, StdError, Tx, TxOutcome, Uint256, Uint64,
+        UnsignedTx,
     },
     grug_vm_rust::RustVm,
     serde::{de::DeserializeOwned, ser::Serialize},
@@ -485,14 +485,15 @@ where
         .into()
     }
 
-    pub fn query_wasm_super_smart<R>(&self, contract: Addr, msg: R) -> GenericResult<R::Response>
+    pub fn query_wasm_super_smart<R>(&self, contract: Addr, req: R) -> GenericResult<R::Response>
     where
-        R: AsQueryMsg + QueryResponseType,
-        <R as AsQueryMsg>::QueryMsg: Serialize,
-        <R as QueryResponseType>::Response: DeserializeOwned,
+        R: QueryRequest,
+        R::Message: Serialize,
+        R::Response: DeserializeOwned,
     {
         (|| -> AppResult<_> {
-            let msg_raw = to_json_value(&msg.into_query_msg())?;
+            let msg = R::Message::from(req);
+            let msg_raw = to_json_value(&msg)?;
             let res_raw = self
                 .app
                 .do_query_app(

--- a/crates/testing/tests/queries.rs
+++ b/crates/testing/tests/queries.rs
@@ -2,6 +2,7 @@ use {
     grug_testing::TestBuilder,
     grug_types::{Coins, Empty, NonZero},
     grug_vm_rust::ContractBuilder,
+    query_super_smart::{AskConfigRequest, ConfigHost, QueryMsgClient},
 };
 
 mod query_maker {
@@ -49,6 +50,129 @@ fn handling_multi_query() -> anyhow::Result<()> {
         &Empty {},
         Coins::new(),
     )?;
+
+    Ok(())
+}
+
+mod query_super_smart {
+    use {
+        borsh::{BorshDeserialize, BorshSerialize},
+        grug_storage::Item,
+        grug_types::{
+            to_json_value, Addr, Empty, ImmutableCtx, Json, MutableCtx, Response, Uint128,
+        },
+        serde::{Deserialize, Serialize},
+    };
+
+    const CONFIG: Item<ConfigHost> = Item::new("c");
+
+    #[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
+    pub struct ConfigHost {
+        pub owner: String,
+        pub balance: Uint128,
+    }
+
+    #[derive(Serialize, Deserialize, grug_macros::Query)]
+    #[query_path_override(::grug_types)]
+    pub enum QueryMsgHost {
+        #[returns(ConfigHost)]
+        Config {},
+    }
+
+    pub fn instantiate_host(ctx: MutableCtx, config: ConfigHost) -> anyhow::Result<Response> {
+        CONFIG.save(ctx.storage, &config)?;
+        Ok(Response::new())
+    }
+
+    pub fn query_host(ctx: ImmutableCtx, msg: QueryMsgHost) -> anyhow::Result<Json> {
+        match msg {
+            QueryMsgHost::Config {} => Ok(to_json_value(&CONFIG.load(ctx.storage)?)?),
+        }
+    }
+
+    // ---- Client ----
+    #[derive(Serialize, Deserialize, grug_macros::Query)]
+    #[query_path_override(::grug_types)]
+    pub enum QueryMsgClient {
+        #[returns(ConfigHost)]
+        AskConfig { contract: Addr },
+    }
+
+    pub fn instantiate_client(_: MutableCtx, _: Empty) -> anyhow::Result<Response> {
+        Ok(Response::new())
+    }
+
+    pub fn query_client(ctx: ImmutableCtx, msg: QueryMsgClient) -> anyhow::Result<Json> {
+        match msg {
+            QueryMsgClient::AskConfig { contract } => {
+                let request = ConfigRequest {};
+                let response = ctx.querier.query_wasm_super_smart(contract, request)?;
+
+                Ok(to_json_value(&response)?)
+            },
+        }
+    }
+}
+
+#[test]
+fn query_super_smart() -> anyhow::Result<()> {
+    let (mut suite, accounts) = TestBuilder::new()
+        .add_account("larry", Coins::one("uusdc", NonZero::new(123_u128)))?
+        .set_chain_id("kebab")
+        .set_owner("larry")?
+        .build()?;
+
+    let host_contract = ContractBuilder::new(Box::new(query_super_smart::instantiate_host))
+        .with_query(Box::new(query_super_smart::query_host))
+        .build();
+
+    let client_contract = ContractBuilder::new(Box::new(query_super_smart::instantiate_client))
+        .with_query(Box::new(query_super_smart::query_client))
+        .build();
+
+    // If the contract successfully deploys, the multi query must have worked.
+    let (_, host_contract) = suite.upload_and_instantiate(
+        &accounts["larry"],
+        host_contract,
+        "host_contract",
+        &ConfigHost {
+            owner: "rhaki".to_string(),
+            balance: 123_u128.into(),
+        },
+        Coins::new(),
+    )?;
+
+    let (_, client_contract) = suite.upload_and_instantiate(
+        &accounts["larry"],
+        client_contract,
+        "client_contract",
+        &Empty {},
+        Coins::new(),
+    )?;
+
+    // Standard query_wasm_smart on suite
+
+    {
+        let result: ConfigHost = suite
+            .query_wasm_smart(client_contract, &QueryMsgClient::AskConfig {
+                contract: host_contract,
+            })
+            .should_succeed();
+
+        assert_eq!(result.owner, "rhaki");
+        assert_eq!(result.balance, 123_u128.into());
+    }
+
+    {
+        let result = suite
+            .query_wasm_super_smart(client_contract, AskConfigRequest {
+                contract: host_contract,
+            })
+            .should_succeed();
+
+        assert_eq!(result.owner, "rhaki");
+        assert_eq!(result.balance, 123_u128.into());
+    }
 
     Ok(())
 }

--- a/crates/testing/tests/queries.rs
+++ b/crates/testing/tests/queries.rs
@@ -2,7 +2,6 @@ use {
     grug_testing::TestBuilder,
     grug_types::{Coins, Empty, NonZero},
     grug_vm_rust::ContractBuilder,
-    query_super_smart::{AskConfigRequest, ConfigHost, QueryMsgClient},
 };
 
 mod query_maker {
@@ -50,129 +49,6 @@ fn handling_multi_query() -> anyhow::Result<()> {
         &Empty {},
         Coins::new(),
     )?;
-
-    Ok(())
-}
-
-mod query_super_smart {
-    use {
-        borsh::{BorshDeserialize, BorshSerialize},
-        grug_storage::Item,
-        grug_types::{
-            to_json_value, Addr, Empty, ImmutableCtx, Json, MutableCtx, Response, Uint128,
-        },
-        serde::{Deserialize, Serialize},
-    };
-
-    const CONFIG: Item<ConfigHost> = Item::new("c");
-
-    #[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
-    pub struct ConfigHost {
-        pub owner: String,
-        pub balance: Uint128,
-    }
-
-    #[derive(Serialize, Deserialize, grug_macros::Query)]
-    #[query_path_override(::grug_types)]
-    pub enum QueryMsgHost {
-        #[returns(ConfigHost)]
-        Config {},
-    }
-
-    pub fn instantiate_host(ctx: MutableCtx, config: ConfigHost) -> anyhow::Result<Response> {
-        CONFIG.save(ctx.storage, &config)?;
-        Ok(Response::new())
-    }
-
-    pub fn query_host(ctx: ImmutableCtx, msg: QueryMsgHost) -> anyhow::Result<Json> {
-        match msg {
-            QueryMsgHost::Config {} => Ok(to_json_value(&CONFIG.load(ctx.storage)?)?),
-        }
-    }
-
-    // ---- Client ----
-    #[derive(Serialize, Deserialize, grug_macros::Query)]
-    #[query_path_override(::grug_types)]
-    pub enum QueryMsgClient {
-        #[returns(ConfigHost)]
-        AskConfig { contract: Addr },
-    }
-
-    pub fn instantiate_client(_: MutableCtx, _: Empty) -> anyhow::Result<Response> {
-        Ok(Response::new())
-    }
-
-    pub fn query_client(ctx: ImmutableCtx, msg: QueryMsgClient) -> anyhow::Result<Json> {
-        match msg {
-            QueryMsgClient::AskConfig { contract } => {
-                let request = ConfigRequest {};
-                let response = ctx.querier.query_wasm_super_smart(contract, request)?;
-
-                Ok(to_json_value(&response)?)
-            },
-        }
-    }
-}
-
-#[test]
-fn query_super_smart() -> anyhow::Result<()> {
-    let (mut suite, accounts) = TestBuilder::new()
-        .add_account("larry", Coins::one("uusdc", NonZero::new(123_u128)))?
-        .set_chain_id("kebab")
-        .set_owner("larry")?
-        .build()?;
-
-    let host_contract = ContractBuilder::new(Box::new(query_super_smart::instantiate_host))
-        .with_query(Box::new(query_super_smart::query_host))
-        .build();
-
-    let client_contract = ContractBuilder::new(Box::new(query_super_smart::instantiate_client))
-        .with_query(Box::new(query_super_smart::query_client))
-        .build();
-
-    // If the contract successfully deploys, the multi query must have worked.
-    let (_, host_contract) = suite.upload_and_instantiate(
-        &accounts["larry"],
-        host_contract,
-        "host_contract",
-        &ConfigHost {
-            owner: "rhaki".to_string(),
-            balance: 123_u128.into(),
-        },
-        Coins::new(),
-    )?;
-
-    let (_, client_contract) = suite.upload_and_instantiate(
-        &accounts["larry"],
-        client_contract,
-        "client_contract",
-        &Empty {},
-        Coins::new(),
-    )?;
-
-    // Standard query_wasm_smart on suite
-
-    {
-        let result: ConfigHost = suite
-            .query_wasm_smart(client_contract, &QueryMsgClient::AskConfig {
-                contract: host_contract,
-            })
-            .should_succeed();
-
-        assert_eq!(result.owner, "rhaki");
-        assert_eq!(result.balance, 123_u128.into());
-    }
-
-    {
-        let result = suite
-            .query_wasm_super_smart(client_contract, AskConfigRequest {
-                contract: host_contract,
-            })
-            .should_succeed();
-
-        assert_eq!(result.owner, "rhaki");
-        assert_eq!(result.balance, 123_u128.into());
-    }
 
     Ok(())
 }

--- a/crates/types/src/imports.rs
+++ b/crates/types/src/imports.rs
@@ -379,20 +379,7 @@ impl<'a> QuerierWrapper<'a> {
             .map(|res| res.as_wasm_raw())
     }
 
-    pub fn query_wasm_smart<M, R>(&self, contract: Addr, msg: &M) -> StdResult<R>
-    where
-        M: Serialize,
-        R: DeserializeOwned,
-    {
-        self.inner
-            .query_chain(Query::WasmSmart {
-                contract,
-                msg: to_json_value(msg)?,
-            })
-            .and_then(|res| from_json_value(res.as_wasm_smart()))
-    }
-
-    pub fn query_wasm_super_smart<R>(&self, contract: Addr, req: R) -> StdResult<R::Response>
+    pub fn query_wasm_smart<R>(&self, contract: Addr, req: R) -> StdResult<R::Response>
     where
         R: QueryRequest,
         R::Message: Serialize,

--- a/crates/types/src/imports.rs
+++ b/crates/types/src/imports.rs
@@ -11,9 +11,8 @@
 
 use {
     crate::{
-        from_json_value, to_json_value, Account, Addr, AsQueryMsg, Batch, Binary, Coins, Hash256,
-        InfoResponse, Json, Op, Order, Query, QueryResponse, QueryResponseType, Record, StdResult,
-        Uint256,
+        from_json_value, to_json_value, Account, Addr, Batch, Binary, Coins, Hash256, InfoResponse,
+        Json, Op, Order, Query, QueryRequest, QueryResponse, Record, StdResult, Uint256,
     },
     dyn_clone::DynClone,
     serde::{de::DeserializeOwned, ser::Serialize},
@@ -393,18 +392,18 @@ impl<'a> QuerierWrapper<'a> {
             .and_then(|res| from_json_value(res.as_wasm_smart()))
     }
 
-    pub fn query_wasm_super_smart<R>(&self, contract: Addr, msg: R) -> StdResult<R::Response>
+    pub fn query_wasm_super_smart<R>(&self, contract: Addr, req: R) -> StdResult<R::Response>
     where
-        R: AsQueryMsg + QueryResponseType,
-        <R as AsQueryMsg>::QueryMsg: Serialize,
-        <R as QueryResponseType>::Response: DeserializeOwned,
+        R: QueryRequest,
+        R::Message: Serialize,
+        R::Response: DeserializeOwned,
     {
-        let request = msg.into_query_msg();
+        let msg = R::Message::from(req);
 
         self.inner
             .query_chain(Query::WasmSmart {
                 contract,
-                msg: to_json_value(&request)?,
+                msg: to_json_value(&msg)?,
             })
             .and_then(|res| from_json_value(res.as_wasm_smart()))
     }

--- a/crates/types/src/query.rs
+++ b/crates/types/src/query.rs
@@ -5,6 +5,18 @@ use {
     std::collections::BTreeMap,
 };
 
+/// Represents a query request to a contract.
+///
+/// A contract typically exposes multiple query methods, with a `QueryMsg` as an
+/// enum with multiple variants. A `QueryRequest` represents one such variant.
+pub trait QueryRequest: Sized {
+    /// The full query message enum that contains this request.
+    type Message: From<Self>;
+
+    /// The response type for this query.
+    type Response;
+}
+
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -194,20 +206,5 @@ impl QueryResponse {
             panic!("QueryResponse is not Multi");
         };
         resp
-    }
-}
-
-pub trait QueryResponseType {
-    type Response;
-}
-
-pub trait AsQueryMsg: Sized
-where
-    <Self as AsQueryMsg>::QueryMsg: From<Self>,
-{
-    type QueryMsg;
-
-    fn into_query_msg(self) -> Self::QueryMsg {
-        self.into()
     }
 }

--- a/crates/types/src/query.rs
+++ b/crates/types/src/query.rs
@@ -196,3 +196,18 @@ impl QueryResponse {
         resp
     }
 }
+
+pub trait QueryResponseType {
+    type Response;
+}
+
+pub trait AsQueryMsg: Sized
+where
+    <Self as AsQueryMsg>::QueryMsg: From<Self>,
+{
+    type QueryMsg;
+
+    fn into_query_msg(self) -> Self::QueryMsg {
+        self.into()
+    }
+}

--- a/crates/vm/wasm/tests/wasm_vm.rs
+++ b/crates/vm/wasm/tests/wasm_vm.rs
@@ -1,8 +1,8 @@
 use {
     grug_testing::TestBuilder,
     grug_types::{
-        to_json_value, Addr, Binary, Coins, Empty, Message, MultiplyFraction, NonZero, NumberConst,
-        Udec128, Uint256,
+        to_json_value, Binary, Coins, Message, MultiplyFraction, NonZero, NumberConst, Udec128,
+        Uint256,
     },
     grug_vm_wasm::{VmError, WasmVm},
     std::{collections::BTreeMap, fs, io, str::FromStr, vec},
@@ -76,14 +76,11 @@ fn bank_transfers() -> anyhow::Result<()> {
 
     // List all holders of the denom
     suite
-        .query_wasm_smart::<_, BTreeMap<Addr, Uint256>>(
-            info.config.bank,
-            &grug_bank::QueryMsg::Holders {
-                denom: DENOM.to_string(),
-                start_after: None,
-                limit: None,
-            },
-        )
+        .query_wasm_smart(info.config.bank, grug_bank::QueryHoldersRequest {
+            denom: DENOM.to_string(),
+            start_after: None,
+            limit: None,
+        })
         .should_succeed_and_equal(BTreeMap::from([
             (accounts["owner"].address, fee),
             (accounts["sender"].address, sender_balance_after),
@@ -194,7 +191,7 @@ fn immutable_state() -> anyhow::Result<()> {
     // This tests how the VM handles state mutability while serving the `Query`
     // ABCI request.
     suite
-        .query_wasm_smart::<_, Empty>(tester, &grug_tester::QueryMsg::ForceWrite {
+        .query_wasm_smart(tester, grug_tester::QueryForceWriteRequest {
             key: "larry".to_string(),
             value: "engineer".to_string(),
         })


### PR DESCRIPTION
`gurg_macro::Query` is a new `proc_macro_derive` that automatize some traits implementation and Struct generation for improve the developer experience for execute query between contracts. 

Usage:
```rust
#[derive(grug::Query)]
#[grug::derive(serde)]
pub enum QueryMsg {
   #[returns(ConfigResponse)
   Config {}
   #[returns(StateResponse)
   State(StateRequest)
}
``` 

`grug::Query` check each enum variant and if the variant is `syn::Fields::Named` (like `Config {}`), a new `Struct` called `ConfigRequest` is created with the same parameters (no one in this case).

```rust
pub struct ConfigRequest {}
```

Then for each `Request` `Struct` the macro impl `impl From<#struct_name> for #name` and the trait `QueryResponseType` for mapping `Request => Response`.

Also QuerierWrapper expose a new method called `query_wasm_super_smart`

```rust
pub fn query_wasm_super_smart<R>(&self, contract: Addr, msg: R) -> StdResult<R::Response>
where
    R: AsQueryMsg + QueryResponseType,
    <R as AsQueryMsg>::QueryMsg: Serialize,
    <R as QueryResponseType>::Response: DeserializeOwned,
{
    let request = msg.into_query_msg();

    self.inner
        .query_chain(QueryRequest::WasmSmart {
            contract,
            msg: to_json_value(&request)?,
        })
        .and_then(|res| from_json_value(res.as_wasm_smart()))
}
```



