### PR TITLE
Rename `Key` to `PrimaryKey`

### DIFF
--- a/crates/app/src/gas/storage.rs
+++ b/crates/app/src/gas/storage.rs
@@ -1,6 +1,6 @@
 use {
     crate::{GasTracker, GAS_COSTS},
-    grug_storage::{Bound, Codec, Item, Key, Map},
+    grug_storage::{Bound, Codec, Item, Map, PrimaryKey},
     grug_types::{Order, Record, StdResult, Storage},
 };
 
@@ -53,7 +53,7 @@ where
 
 pub trait MeteredMap<K, T>
 where
-    K: Key,
+    K: PrimaryKey,
 {
     fn load_with_gas(&self, storage: &dyn Storage, gas_tracker: GasTracker, key: K)
         -> StdResult<T>;
@@ -85,7 +85,7 @@ where
 
 impl<'a, K, T, C> MeteredMap<K, T> for Map<'a, K, T, C>
 where
-    K: Key,
+    K: PrimaryKey,
     C: Codec<T>,
 {
     fn load_with_gas(
@@ -126,7 +126,7 @@ where
         min: Option<Bound<K>>,
         max: Option<Bound<K>>,
         order: Order,
-    ) -> StdResult<Box<dyn Iterator<Item = StdResult<(<K as Key>::Output, T)>> + 'b>> {
+    ) -> StdResult<Box<dyn Iterator<Item = StdResult<(K::Output, T)>> + 'b>> {
         // Gas cost for creating an iterator.
         gas_tracker.consume(GAS_COSTS.db_scan, "db_scan")?;
 

--- a/crates/jellyfish-merkle/src/bitarray.rs
+++ b/crates/jellyfish-merkle/src/bitarray.rs
@@ -1,5 +1,5 @@
 use {
-    grug_storage::Key,
+    grug_storage::PrimaryKey,
     grug_types::{split_one_key, Hash256, Order, StdResult},
     std::{borrow::Cow, fmt},
 };
@@ -164,7 +164,7 @@ impl PartialEq<Hash256> for BitArray {
     }
 }
 
-impl<'a> Key for &'a BitArray {
+impl<'a> PrimaryKey for &'a BitArray {
     type Output = BitArray;
     type Prefix = u16;
     type Suffix = &'a [u8];

--- a/crates/storage/src/bound.rs
+++ b/crates/storage/src/bound.rs
@@ -1,4 +1,4 @@
-use crate::{Key, Prefixer};
+use crate::{Prefixer, PrimaryKey};
 
 // --------------------------------- raw bound ---------------------------------
 
@@ -41,7 +41,7 @@ impl<K> Bound<K> {
 
 impl<K> From<Bound<K>> for RawBound
 where
-    K: Key,
+    K: PrimaryKey,
 {
     fn from(bound: Bound<K>) -> Self {
         match bound {
@@ -55,7 +55,7 @@ where
 
 pub enum PrefixBound<K>
 where
-    K: Key,
+    K: PrimaryKey,
 {
     Inclusive(K::Prefix),
     Exclusive(K::Prefix),
@@ -63,7 +63,7 @@ where
 
 impl<K> PrefixBound<K>
 where
-    K: Key,
+    K: PrimaryKey,
 {
     pub fn inclusive<P>(p: P) -> Self
     where
@@ -82,7 +82,7 @@ where
 
 impl<K> From<PrefixBound<K>> for RawBound
 where
-    K: Key,
+    K: PrimaryKey,
 {
     fn from(bound: PrefixBound<K>) -> Self {
         match bound {

--- a/crates/storage/src/counter.rs
+++ b/crates/storage/src/counter.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Borsh, Codec, Item, Key, Map},
+    crate::{Borsh, Codec, Item, Map, PrimaryKey},
     grug_types::{Number, StdResult, Storage},
 };
 
@@ -74,7 +74,7 @@ where
 }
 impl<'a, K, T, C> Counters<'a, K, T, C>
 where
-    K: Key + Copy,
+    K: PrimaryKey + Copy,
     T: Number + Copy,
     C: Codec<T>,
 {

--- a/crates/storage/src/index/map.rs
+++ b/crates/storage/src/index/map.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Borsh, Bound, Codec, Key, Map, Prefix, PrefixBound},
+    crate::{Borsh, Bound, Codec, Map, Prefix, PrefixBound, PrimaryKey},
     grug_types::{Order, Record, StdError, StdResult, Storage},
 };
 
@@ -25,7 +25,7 @@ where
 
 impl<'a, K, T, I, C> IndexedMap<'a, K, T, I, C>
 where
-    K: Key,
+    K: PrimaryKey,
     C: Codec<T>,
 {
     pub const fn new(pk_namespace: &'static str, indexes: I) -> Self {
@@ -215,7 +215,7 @@ where
 
 impl<'a, K, T, I, C> IndexedMap<'a, K, T, I, C>
 where
-    K: Key + Clone,
+    K: PrimaryKey + Clone,
     I: IndexList<K, T>,
     C: Codec<T>,
 {
@@ -259,7 +259,7 @@ where
 
 impl<'a, K, T, I, C> IndexedMap<'a, K, T, I, C>
 where
-    K: Key + Clone,
+    K: PrimaryKey + Clone,
     T: Clone,
     I: IndexList<K, T>,
     C: Codec<T>,

--- a/crates/storage/src/index/multi.rs
+++ b/crates/storage/src/index/multi.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{split_first_key, Borsh, Bound, Codec, Index, Key, Map, Prefix, Prefixer, Set},
+    crate::{split_first_key, Borsh, Bound, Codec, Index, Map, Prefix, Prefixer, PrimaryKey, Set},
     grug_types::{Empty, Order, Record, StdResult, Storage},
     std::marker::PhantomData,
 };
@@ -10,8 +10,8 @@ use {
 /// index value.
 pub struct MultiIndex<'a, PK, IK, T, C = Borsh>
 where
-    PK: Key,
-    IK: Key + Prefixer,
+    PK: PrimaryKey,
+    IK: PrimaryKey + Prefixer,
     C: Codec<T>,
 {
     indexer: fn(&PK, &T) -> IK,
@@ -22,8 +22,8 @@ where
 
 impl<'a, PK, IK, T, C> MultiIndex<'a, PK, IK, T, C>
 where
-    PK: Key,
-    IK: Key + Prefixer,
+    PK: PrimaryKey,
+    IK: PrimaryKey + Prefixer,
     C: Codec<T>,
 {
     pub const fn new(
@@ -178,8 +178,8 @@ where
 
 impl<'a, PK, IK, T, C> Index<PK, T> for MultiIndex<'a, PK, IK, T, C>
 where
-    PK: Key,
-    IK: Key + Prefixer,
+    PK: PrimaryKey,
+    IK: PrimaryKey + Prefixer,
     C: Codec<T>,
 {
     fn save(&self, storage: &mut dyn Storage, pk: PK, data: &T) -> StdResult<()> {
@@ -208,7 +208,7 @@ where
 
 impl<'a, IK, PK, B, T, C> IndexPrefix<'a, IK, PK, B, T, C>
 where
-    B: Key,
+    B: PrimaryKey,
     C: Codec<T>,
 {
     pub fn append(self, prefix: B::Prefix) -> IndexPrefix<'a, IK, PK, B::Suffix, T, C> {
@@ -223,9 +223,9 @@ where
 
 impl<'a, IK, PK, B, T, C> IndexPrefix<'a, IK, PK, B, T, C>
 where
-    IK: Key,
-    PK: Key,
-    B: Key,
+    IK: PrimaryKey,
+    PK: PrimaryKey,
+    B: PrimaryKey,
     C: Codec<T>,
 {
     /// Iterate the raw primary keys and raw values under the given index value.

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Borsh, Bound, Codec, Index, Key, Map, Raw},
+    crate::{Borsh, Bound, Codec, Index, Map, PrimaryKey, Raw},
     grug_types::{Order, StdError, StdResult, Storage},
 };
 
@@ -14,8 +14,8 @@ use {
 /// - in the index map: (idx_namespace, ik) => value
 pub struct UniqueIndex<'a, PK, IK, T, C = Borsh>
 where
-    PK: Key,
-    IK: Key + Clone,
+    PK: PrimaryKey,
+    IK: PrimaryKey + Clone,
     C: Codec<T>,
 {
     /// A function that takes a key-value pair, and return the index key it
@@ -29,8 +29,8 @@ where
 
 impl<'a, PK, IK, T, C> UniqueIndex<'a, PK, IK, T, C>
 where
-    PK: Key,
-    IK: Key + Clone,
+    PK: PrimaryKey,
+    IK: PrimaryKey + Clone,
     C: Codec<T>,
 {
     /// Note: The developer must make sure that `idx_namespace` is not the same
@@ -243,8 +243,8 @@ where
 
 impl<'a, PK, IK, T, C> Index<PK, T> for UniqueIndex<'a, PK, IK, T, C>
 where
-    PK: Key,
-    IK: Key + Clone,
+    PK: PrimaryKey,
+    IK: PrimaryKey + Clone,
     C: Codec<T>,
 {
     fn save(&self, storage: &mut dyn Storage, pk: PK, data: &T) -> StdResult<()> {

--- a/crates/storage/src/key.rs
+++ b/crates/storage/src/key.rs
@@ -17,7 +17,7 @@ use {
 ///
 /// Additionally, compound keys can be split into `Prefix` and `Suffix`, which
 /// are useful in iterations.
-pub trait Key {
+pub trait PrimaryKey {
     /// The number of elements in a tuple key.
     ///
     /// E.g.,
@@ -99,7 +99,7 @@ pub trait Key {
     fn from_slice(bytes: &[u8]) -> StdResult<Self::Output>;
 }
 
-impl Key for () {
+impl PrimaryKey for () {
     type Output = ();
     type Prefix = ();
     type Suffix = ();
@@ -122,7 +122,7 @@ impl Key for () {
     }
 }
 
-impl Key for &[u8] {
+impl PrimaryKey for &[u8] {
     type Output = Vec<u8>;
     type Prefix = ();
     type Suffix = ();
@@ -138,7 +138,7 @@ impl Key for &[u8] {
     }
 }
 
-impl Key for Vec<u8> {
+impl PrimaryKey for Vec<u8> {
     type Output = Vec<u8>;
     type Prefix = ();
     type Suffix = ();
@@ -154,7 +154,7 @@ impl Key for Vec<u8> {
     }
 }
 
-impl Key for &str {
+impl PrimaryKey for &str {
     type Output = String;
     type Prefix = ();
     type Suffix = ();
@@ -171,7 +171,7 @@ impl Key for &str {
     }
 }
 
-impl Key for String {
+impl PrimaryKey for String {
     type Output = String;
     type Prefix = ();
     type Suffix = ();
@@ -188,7 +188,7 @@ impl Key for String {
     }
 }
 
-impl Key for Addr {
+impl PrimaryKey for Addr {
     type Output = Addr;
     type Prefix = ();
     type Suffix = ();
@@ -204,7 +204,7 @@ impl Key for Addr {
     }
 }
 
-impl<const N: usize> Key for Hash<N> {
+impl<const N: usize> PrimaryKey for Hash<N> {
     type Output = Hash<N>;
     type Prefix = ();
     type Suffix = ();
@@ -220,7 +220,7 @@ impl<const N: usize> Key for Hash<N> {
     }
 }
 
-impl Key for Duration {
+impl PrimaryKey for Duration {
     type Output = Duration;
     type Prefix = ();
     type Suffix = ();
@@ -237,9 +237,9 @@ impl Key for Duration {
     }
 }
 
-impl<K> Key for &K
+impl<K> PrimaryKey for &K
 where
-    K: Key,
+    K: PrimaryKey,
 {
     type Output = K::Output;
     type Prefix = K::Prefix;
@@ -256,10 +256,10 @@ where
     }
 }
 
-impl<A, B> Key for (A, B)
+impl<A, B> PrimaryKey for (A, B)
 where
-    A: Key + Prefixer,
-    B: Key,
+    A: PrimaryKey + Prefixer,
+    B: PrimaryKey,
 {
     type Output = (A::Output, B::Output);
     type Prefix = A;
@@ -283,11 +283,11 @@ where
     }
 }
 
-impl<A, B, C> Key for (A, B, C)
+impl<A, B, C> PrimaryKey for (A, B, C)
 where
-    A: Key + Prefixer,
-    B: Key,
-    C: Key,
+    A: PrimaryKey + Prefixer,
+    B: PrimaryKey,
+    C: PrimaryKey,
 {
     type Output = (A::Output, B::Output, C::Output);
     // Here we make `A` as the prefix and `(B, C)` as the suffix.
@@ -379,7 +379,7 @@ pub(crate) fn split_first_key(key_elems: u8, value: &[u8]) -> (Vec<u8>, &[u8]) {
 
 macro_rules! impl_integer_key {
     ($($t:ty),+ $(,)?) => {
-        $(impl Key for $t {
+        $(impl PrimaryKey for $t {
             type Prefix = ();
             type Suffix = ();
             type Output = $t;

--- a/crates/storage/src/map.rs
+++ b/crates/storage/src/map.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Borsh, Bound, Codec, Key, PathBuf, Prefix, PrefixBound, Prefixer},
+    crate::{Borsh, Bound, Codec, PathBuf, Prefix, PrefixBound, Prefixer, PrimaryKey},
     grug_types::{Order, Record, StdError, StdResult, Storage},
     std::{borrow::Cow, marker::PhantomData},
 };
@@ -32,7 +32,7 @@ where
 
 impl<'a, K, T, C> Map<'a, K, T, C>
 where
-    K: Key,
+    K: PrimaryKey,
     C: Codec<T>,
 {
     fn path_raw(&self, key_raw: &[u8]) -> PathBuf<T, C> {

--- a/crates/storage/src/prefix.rs
+++ b/crates/storage/src/prefix.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Bound, Codec, Key, PrefixBound, Prefixer, RawBound},
+    crate::{Bound, Codec, PrefixBound, Prefixer, PrimaryKey, RawBound},
     grug_types::{
         concat, encode_length, extend_one_byte, increment_last_byte, nested_namespaces_with_key,
         trim, Order, Record, StdResult, Storage,
@@ -37,7 +37,7 @@ where
 
 impl<K, T, C> Prefix<K, T, C>
 where
-    K: Key,
+    K: PrimaryKey,
     C: Codec<T>,
 {
     pub fn append(mut self, prefix: K::Prefix) -> Prefix<K::Suffix, T, C> {
@@ -297,7 +297,7 @@ fn range_bounds<K>(
     max: Option<Bound<K>>,
 ) -> (Vec<u8>, Vec<u8>)
 where
-    K: Key,
+    K: PrimaryKey,
 {
     let min = match min.map(RawBound::from) {
         None => namespace.to_vec(),
@@ -319,7 +319,7 @@ fn range_prefix_bounds<K>(
     max: Option<PrefixBound<K>>,
 ) -> (Vec<u8>, Vec<u8>)
 where
-    K: Key,
+    K: PrimaryKey,
 {
     let min = match min.map(RawBound::from) {
         None => namespace.to_vec(),

--- a/crates/storage/src/set.rs
+++ b/crates/storage/src/set.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Borsh, Bound, Codec, Key, PathBuf, Prefix, PrefixBound, Prefixer},
+    crate::{Borsh, Bound, Codec, PathBuf, Prefix, PrefixBound, Prefixer, PrimaryKey},
     grug_types::{Empty, Order, StdResult, Storage},
     std::{borrow::Cow, marker::PhantomData},
 };
@@ -34,7 +34,7 @@ where
 
 impl<'a, T, C> Set<'a, T, C>
 where
-    T: Key,
+    T: PrimaryKey,
     C: Codec<Empty>,
 {
     fn path_raw(&self, key_raw: &[u8]) -> PathBuf<Empty, Borsh> {


### PR DESCRIPTION
As we discussed, the word "key" can have two meanings:

- a database key
- a cryptographic key

which can be confusing.

`PrimaryKey` can be a better naming, because it's commonly used in database context, and aligns with CosmWasm. 