### PR TITLE
`gurg::derive` impl `QueryRequest`

### DIFF
--- a/crates/std/tests/queries.rs
+++ b/crates/std/tests/queries.rs
@@ -8,8 +8,7 @@ mod super_smart_querier {
         to_json_value, Addr, Empty, Hash256, ImmutableCtx, Json, MutableCtx, Response, StdResult,
     };
 
-    #[grug::derive(serde)]
-    #[derive(grug::QueryRequest)]
+    #[grug::derive(serde, query)]
     pub enum QueryMsg {
         #[returns(String)]
         Foo { bar: u64 },


### PR DESCRIPTION
`grug::derive` can now implement `QueryRequest` adding the keyword `query` as attribute like:
```rust
#[grug::derive(serde, query)]
pub enum QueryMsg {
    #[returns(String)]
    Foo { bar: u64 },
    #[returns(Addr)]
    Fuzz(u8),
    #[returns(Hash256)]
    Buzz,
}
```