### PR TITLE
Replace hasher functions with extension trait

### DIFF
--- a/crates/app/src/execute.rs
+++ b/crates/app/src/execute.rs
@@ -6,8 +6,8 @@ use {
         CHAIN_ID, CODES, CONFIG, NEXT_CRONJOBS,
     },
     grug_types::{
-        hash256, Account, Addr, AuthMode, AuthResponse, BankMsg, Binary, BlockInfo, Coins,
-        ConfigUpdates, Context, Event, GenericResult, Hash256, Json, Op, Storage, SubMsgResult, Tx,
+        Account, Addr, AuthMode, AuthResponse, BankMsg, Binary, BlockInfo, Coins, ConfigUpdates,
+        Context, Event, GenericResult, Hash256, HashExt, Json, Op, Storage, SubMsgResult, Tx,
         TxOutcome,
     },
     std::collections::BTreeMap,
@@ -138,7 +138,7 @@ fn _do_upload(
     }
 
     // Make sure that the same code isn't already uploaded
-    let code_hash = hash256(code);
+    let code_hash = code.hash256();
     if CODES.has_with_gas(storage, gas_tracker.clone(), code_hash)? {
         return Err(AppError::CodeExists { code_hash });
     }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -4,9 +4,9 @@ use {
     grug_account::{QueryMsg, StateResponse},
     grug_jmt::Proof,
     grug_types::{
-        from_json_slice, from_json_value, hash256, to_json_value, to_json_vec, Account, Addr,
-        Binary, Coin, Coins, ConfigUpdates, GenericResult, Hash256, InfoResponse, Json, Message,
-        Op, Outcome, Query, QueryResponse, StdError, Tx, UnsignedTx,
+        from_json_slice, from_json_value, to_json_value, to_json_vec, Account, Addr, Binary, Coin,
+        Coins, ConfigUpdates, GenericResult, Hash256, HashExt, InfoResponse, Json, Message, Op,
+        Outcome, Query, QueryResponse, StdError, Tx, UnsignedTx,
     },
     serde::{de::DeserializeOwned, ser::Serialize},
     std::{any::type_name, collections::BTreeMap},
@@ -524,7 +524,7 @@ impl Client {
         StdError: From<C::Error>,
     {
         let code = code.into();
-        let code_hash = hash256(&code);
+        let code_hash = code.hash256();
         let salt = salt.into();
         let address = Addr::compute(sign_opt.sender, code_hash, &salt);
         let admin = admin_opt.decide(address);

--- a/crates/client/src/genesis_builder.rs
+++ b/crates/client/src/genesis_builder.rs
@@ -3,9 +3,9 @@ use {
     anyhow::{bail, ensure},
     chrono::{DateTime, SecondsFormat, Utc},
     grug_types::{
-        from_json_slice, hash256, to_json_value, Addr, Binary, Coins, Config, Defined, Duration,
-        GenesisState, Hash256, Json, Message, Permission, Permissions, StdError, Undefined,
-        GENESIS_SENDER,
+        from_json_slice, to_json_value, Addr, Binary, Coins, Config, Defined, Duration,
+        GenesisState, Hash256, HashExt, Json, Message, Permission, Permissions, StdError,
+        Undefined, GENESIS_SENDER,
     },
     serde::Serialize,
     std::{collections::BTreeMap, fs, path::Path},
@@ -185,7 +185,7 @@ impl<O, B, T, U, I> GenesisBuilder<O, B, T, U, I> {
         D: Into<Binary>,
     {
         let code = code.into();
-        let code_hash = hash256(&code);
+        let code_hash = code.hash256();
 
         self.upload_msgs.push(Message::upload(code));
 

--- a/crates/db/disk/src/db.rs
+++ b/crates/db/disk/src/db.rs
@@ -2,7 +2,7 @@ use {
     crate::{DbError, DbResult, U64Comparator, U64Timestamp},
     grug_app::{Buffer, Db, PrunableDb},
     grug_jmt::{MerkleTree, Proof},
-    grug_types::{hash256, Batch, Hash256, Op, Order, Record, Storage},
+    grug_types::{Batch, Hash256, HashExt, Op, Order, Record, Storage},
     rocksdb::{
         BoundColumnFamily, DBWithThreadMode, IteratorMode, MultiThreaded, Options, ReadOptions,
         WriteBatch,
@@ -196,7 +196,7 @@ impl Db for DiskDb {
 
     fn prove(&self, key: &[u8], version: Option<u64>) -> DbResult<Proof> {
         let version = version.unwrap_or_else(|| self.latest_version().unwrap_or(0));
-        Ok(MERKLE_TREE.prove(&self.state_commitment(), hash256(key), version)?)
+        Ok(MERKLE_TREE.prove(&self.state_commitment(), key.hash256(), version)?)
     }
 
     fn flush_but_not_commit(&self, batch: Batch) -> DbResult<(u64, Option<Hash256>)> {
@@ -906,8 +906,8 @@ mod tests {
                 None,
                 Proof::NonMembership(NonMembershipProof {
                     node: ProofNode::Leaf {
-                        key_hash: hash256(b"jake"),
-                        value_hash: hash256(b"shepherd"),
+                        key_hash: "jake".hash256(),
+                        value_hash: "shepherd".hash256(),
                     },
                     sibling_hashes: vec![Some(v0::HASH_0)],
                 }),
@@ -934,8 +934,8 @@ mod tests {
                 None,
                 Proof::NonMembership(NonMembershipProof {
                     node: ProofNode::Leaf {
-                        key_hash: hash256(b"donald"),
-                        value_hash: hash256(b"duck"),
+                        key_hash: "donald".hash256(),
+                        value_hash: "duck".hash256(),
                     },
                     sibling_hashes: vec![Some(v1::HASH_00), Some(v1::HASH_1)],
                 }),
@@ -967,8 +967,8 @@ mod tests {
             };
             assert!(verify_proof(
                 root_hash,
-                hash256(key.as_bytes()),
-                value.map(hash256),
+                key.as_bytes().hash256(),
+                value.map(|v| v.hash256()),
                 &found_proof,
             )
             .is_ok());

--- a/crates/db/memory/src/db.rs
+++ b/crates/db/memory/src/db.rs
@@ -2,7 +2,7 @@ use {
     crate::{DbError, DbResult, VersionedMap},
     grug_app::{Buffer, Db},
     grug_jmt::{MerkleTree, Proof},
-    grug_types::{hash256, Batch, Hash256, Op, Order, Record, Storage},
+    grug_types::{Batch, Hash256, HashExt, Op, Order, Record, Storage},
     std::{
         collections::HashMap,
         ops::Bound,
@@ -113,7 +113,7 @@ impl Db for MemDb {
 
     fn prove(&self, key: &[u8], version: Option<u64>) -> DbResult<Proof> {
         let version = version.unwrap_or_else(|| self.latest_version().unwrap_or(0));
-        Ok(MERKLE_TREE.prove(&self.state_commitment(), hash256(key), version)?)
+        Ok(MERKLE_TREE.prove(&self.state_commitment(), key.hash256(), version)?)
     }
 
     // Note on implementing this function: We must make sure that we don't

--- a/crates/jellyfish-merkle/src/node.rs
+++ b/crates/jellyfish-merkle/src/node.rs
@@ -1,6 +1,6 @@
 use {
     borsh::{BorshDeserialize, BorshSerialize},
-    grug_types::{hash256, Hash256},
+    grug_types::{Hash256, HashExt},
 };
 
 const INTERNAL_NODE_HASH_PREFIX: &[u8] = &[0];
@@ -64,7 +64,7 @@ pub fn hash_internal_node(left_hash: Option<Hash256>, right_hash: Option<Hash256
     preimage.extend_from_slice(INTERNAL_NODE_HASH_PREFIX);
     preimage.extend_from_slice(&left_hash.unwrap_or(Hash256::ZERO));
     preimage.extend_from_slice(&right_hash.unwrap_or(Hash256::ZERO));
-    hash256(preimage)
+    preimage.hash256()
 }
 
 pub fn hash_leaf_node(key_hash: Hash256, value_hash: Hash256) -> Hash256 {
@@ -72,5 +72,5 @@ pub fn hash_leaf_node(key_hash: Hash256, value_hash: Hash256) -> Hash256 {
     preimage.extend_from_slice(LEAF_NODE_HASH_PERFIX);
     preimage.extend_from_slice(&key_hash);
     preimage.extend_from_slice(&value_hash);
-    hash256(preimage)
+    preimage.hash256()
 }

--- a/crates/jellyfish-merkle/src/proof.rs
+++ b/crates/jellyfish-merkle/src/proof.rs
@@ -173,7 +173,7 @@ fn compute_and_compare_root_hash(
 mod tests {
     use {
         super::*,
-        grug_types::{hash256, Hash256},
+        grug_types::{Hash256, HashExt},
         hex_literal::hex,
         test_case::test_case,
     };
@@ -259,8 +259,8 @@ mod tests {
     fn verifying_membership(key: &str, value: &str, proof: MembershipProof) {
         assert!(verify_membership_proof(
             HASH_ROOT,
-            hash256(key.as_bytes()),
-            hash256(value.as_bytes()),
+            key.as_bytes().hash256(),
+            value.as_bytes().hash256(),
             &proof,
         )
         .is_ok());
@@ -294,7 +294,7 @@ mod tests {
         "proving o"
     )]
     fn verifying_non_membership(key: &str, proof: NonMembershipProof) {
-        assert!(verify_non_membership_proof(HASH_ROOT, hash256(key.as_bytes()), &proof).is_ok());
+        assert!(verify_non_membership_proof(HASH_ROOT, key.as_bytes().hash256(), &proof).is_ok());
     }
 
     // TODO: add fail cases for proofs

--- a/crates/jellyfish-merkle/src/tree.rs
+++ b/crates/jellyfish-merkle/src/tree.rs
@@ -4,7 +4,7 @@ use {
         ProofNode,
     },
     grug_storage::{Map, PrefixBound, Set},
-    grug_types::{hash256, Batch, Hash256, Op, Order, StdResult, Storage},
+    grug_types::{Batch, Hash256, HashExt, Op, Order, StdResult, Storage},
 };
 
 // Default storage namespaces
@@ -99,7 +99,7 @@ impl<'a> MerkleTree<'a> {
         // Hash256 the keys and values
         let mut batch: Vec<_> = batch
             .iter()
-            .map(|(k, op)| (hash256(k), op.as_ref().map(hash256)))
+            .map(|(k, op)| (k.hash256(), op.as_ref().map(|v| v.hash256())))
             .collect();
 
         // Sort by key hashes ascendingly
@@ -979,7 +979,7 @@ mod tests {
     fn proving(key: &str, proof: Proof) {
         let (storage, _) = build_test_case().unwrap();
         assert_eq!(
-            TREE.prove(&storage, hash256(key.as_bytes()), 0).unwrap(),
+            TREE.prove(&storage, key.as_bytes().hash256(), 0).unwrap(),
             proof
         );
     }

--- a/crates/testing/src/builder.rs
+++ b/crates/testing/src/builder.rs
@@ -3,8 +3,8 @@ use {
     anyhow::{anyhow, ensure},
     grug_app::AppError,
     grug_types::{
-        hash256, to_json_value, Addr, Binary, BlockInfo, Coins, Config, Defined, Duration,
-        GenesisState, Json, MaybeDefined, Message, Permission, Permissions, Timestamp, Udec128,
+        to_json_value, Addr, Binary, BlockInfo, Coins, Config, Defined, Duration, GenesisState,
+        HashExt, Json, MaybeDefined, Message, Permission, Permissions, Timestamp, Udec128,
         Undefined, GENESIS_BLOCK_HASH, GENESIS_BLOCK_HEIGHT, GENESIS_SENDER,
     },
     grug_vm_rust::RustVm,
@@ -314,7 +314,7 @@ where
         );
 
         // Generate a random new account
-        let account = TestAccount::new_random(hash256(&self.account_opt.code), name.as_bytes());
+        let account = TestAccount::new_random(self.account_opt.code.hash256(), name.as_bytes());
 
         // Save account and balances
         let balances = balances.try_into()?;
@@ -493,14 +493,14 @@ where
             Message::upload(self.bank_opt.code.clone()),
             Message::upload(self.taxman_opt.code.clone()),
             Message::instantiate(
-                hash256(&self.bank_opt.code),
+                self.bank_opt.code.hash256(),
                 &(self.bank_opt.msg_builder)(self.balances),
                 DEFAULT_BANK_SALT,
                 Coins::new(),
                 None,
             )?,
             Message::instantiate(
-                hash256(&self.taxman_opt.code),
+                self.taxman_opt.code.hash256(),
                 &(self.taxman_opt.msg_builder)(fee_denom, fee_rate),
                 DEFAULT_TAXMAN_SALT,
                 Coins::new(),
@@ -511,7 +511,7 @@ where
         // Instantiate accounts
         for (name, account) in self.accounts.inner() {
             msgs.push(Message::instantiate(
-                hash256(&self.account_opt.code),
+                self.account_opt.code.hash256(),
                 &(self.account_opt.msg_builder)(account.pk),
                 name.to_string(),
                 Coins::new(),
@@ -522,14 +522,14 @@ where
         // Predict bank contract address
         let bank = Addr::compute(
             GENESIS_SENDER,
-            hash256(&self.bank_opt.code),
+            self.bank_opt.code.hash256(),
             DEFAULT_BANK_SALT,
         );
 
         // Prefict taxman contract address
         let taxman = Addr::compute(
             GENESIS_SENDER,
-            hash256(&self.taxman_opt.code),
+            self.taxman_opt.code.hash256(),
             DEFAULT_TAXMAN_SALT,
         );
 

--- a/crates/types/src/address.rs
+++ b/crates/types/src/address.rs
@@ -4,7 +4,7 @@ use {
     sha3::{Digest, Keccak256},
 };
 use {
-    crate::{forward_ref_partial_eq, hash160, hash256, Hash, Hash160, Hash256, StdError},
+    crate::{forward_ref_partial_eq, Hash, Hash160, Hash256, HashExt, StdError},
     borsh::{BorshDeserialize, BorshSerialize},
     core::str,
     serde::{de, ser},
@@ -62,7 +62,7 @@ impl Addr {
         preimage.extend_from_slice(deployer.as_ref());
         preimage.extend_from_slice(code_hash.as_ref());
         preimage.extend_from_slice(salt);
-        Self(hash160(hash256(preimage)))
+        Self(preimage.hash256().hash160())
     }
 
     /// Generate a mock address from use in testing.

--- a/crates/types/src/hash.rs
+++ b/crates/types/src/hash.rs
@@ -9,10 +9,13 @@ use {
     },
 };
 
+/// A 20-byte hash, in lowercase hex encoding.
 pub type Hash160 = Hash<20>;
 
+/// A 32-byte hash, in lowercase hex encoding.
 pub type Hash256 = Hash<32>;
 
+/// A hash of fixed size `N`, in lowercase hex encoding.
 #[derive(BorshSerialize, BorshDeserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Hash<const N: usize>(pub(crate) [u8; N]);
 
@@ -34,14 +37,17 @@ impl<const N: usize> Hash<N> {
 }
 
 impl<const N: usize> Hash<N> {
-    pub const fn from_array(slice: [u8; N]) -> Self {
-        Self(slice)
+    /// Create a new hash from a byte array of the correct length.
+    pub const fn from_array(array: [u8; N]) -> Self {
+        Self(array)
     }
 
+    /// Cast the hash into a byte array.
     pub fn into_array(self) -> [u8; N] {
         self.0
     }
 
+    /// Cast the hash into a byte vector.
     pub fn into_vec(self) -> Vec<u8> {
         self.0.into()
     }

--- a/crates/types/src/hashers.rs
+++ b/crates/types/src/hashers.rs
@@ -5,20 +5,30 @@ use {
     sha2::Sha256,
 };
 
-pub fn hash160<T>(data: T) -> Hash160
-where
-    T: AsRef<[u8]>,
-{
-    let mut hasher = Ripemd160::new();
-    hasher.update(data.as_ref());
-    Hash160::from_array(hasher.finalize().into())
+/// Represents a data that can be hashed.
+pub trait HashExt {
+    /// Hash the data, producing a 20-byte hash.
+    fn hash160(&self) -> Hash160;
+
+    /// Hash the data, producing a 32-byte hash.
+    fn hash256(&self) -> Hash256;
 }
 
-pub fn hash256<T>(data: T) -> Hash256
+// Currently, we use RIPEMD-160 for 20-byte hashes, and SHA2-256 for 32-byte
+// hashes. However, this can change prior to v1. We may consider BLAKE3 for `hash256`.
+impl<T> HashExt for T
 where
     T: AsRef<[u8]>,
 {
-    let mut hasher = Sha256::new();
-    hasher.update(data.as_ref());
-    Hash256::from_array(hasher.finalize().into())
+    fn hash160(&self) -> Hash160 {
+        let mut hasher = Ripemd160::new();
+        hasher.update(self.as_ref());
+        Hash160::from_array(hasher.finalize().into())
+    }
+
+    fn hash256(&self) -> Hash256 {
+        let mut hasher = Sha256::new();
+        hasher.update(self.as_ref());
+        Hash256::from_array(hasher.finalize().into())
+    }
 }


### PR DESCRIPTION
Replace `grug::{hash160,hash256}` functions with the `HashExt` trait.

This is the same as #121, but we split into two PRs: one for hashes, one for serializers.