### PR TITLE
Fixes to ed25519 batch verify

### DIFF
--- a/crates/crypto/src/ed25519.rs
+++ b/crates/crypto/src/ed25519.rs
@@ -50,8 +50,8 @@ pub fn ed25519_batch_verify(
         .into_iter()
         .unzip();
 
-    // No need to check the three slices (`msg_hashes`, `sigs`, `pks`) are of the
-    // length; `ed25519_dalek::verify_batch` already does this.
+    // No need to check the three slices (`prehash_msgs`, `sigs`, `pks`) are of
+    // the same length; `ed25519_dalek::verify_batch` already does this.
     ed25519_dalek::verify_batch(prehash_msgs, &sigs, &vks).map_err(Into::into)
 }
 

--- a/crates/types/src/imports.rs
+++ b/crates/types/src/imports.rs
@@ -216,7 +216,7 @@ pub trait Api {
     /// NOTE: This function takes the hash of the messages, not the prehash.
     fn ed25519_batch_verify(
         &self,
-        msgs_hash: &[&[u8]],
+        prehash_msgs: &[&[u8]],
         sigs: &[&[u8]],
         pks: &[&[u8]],
     ) -> StdResult<()>;

--- a/crates/vm/rust/src/api.rs
+++ b/crates/vm/rust/src/api.rs
@@ -37,11 +37,11 @@ impl Api for InternalApi {
 
     fn ed25519_batch_verify(
         &self,
-        msgs_hash: &[&[u8]],
+        prehash_msgs: &[&[u8]],
         sigs: &[&[u8]],
         pks: &[&[u8]],
     ) -> StdResult<()> {
-        grug_crypto::ed25519_batch_verify(msgs_hash, sigs, pks)
+        grug_crypto::ed25519_batch_verify(prehash_msgs, sigs, pks)
             .map_err(|err| VerificationError::from_error_code(err.into_error_code()).into())
     }
 

--- a/crates/vm/wasm/src/imports.rs
+++ b/crates/vm/wasm/src/imports.rs
@@ -338,27 +338,27 @@ pub fn ed25519_verify(
 
 pub fn ed25519_batch_verify(
     mut fe: FunctionEnvMut<Environment>,
-    msgs_hash_ptr: u32,
+    prehash_msgs_ptr: u32,
     sigs_ptr: u32,
     pks_ptr: u32,
 ) -> VmResult<u32> {
     let (env, mut store) = fe.data_and_store_mut();
 
-    let msgs_hash = read_from_memory(env, &store, msgs_hash_ptr)?;
+    let prehash_msgs = read_from_memory(env, &store, prehash_msgs_ptr)?;
     let sigs = read_from_memory(env, &store, sigs_ptr)?;
     let pks = read_from_memory(env, &store, pks_ptr)?;
 
-    let msgs_hash = decode_sections(&msgs_hash);
+    let prehash_msgs = decode_sections(&prehash_msgs);
     let sigs = decode_sections(&sigs);
     let pks = decode_sections(&pks);
 
     env.consume_external_gas(
         &mut store,
-        GAS_COSTS.ed25519_batch_verify.cost(msgs_hash.len()),
+        GAS_COSTS.ed25519_batch_verify.cost(prehash_msgs.len()),
         "ed25519_batch_verify",
     )?;
 
-    match grug_crypto::ed25519_batch_verify(&msgs_hash, &sigs, &pks) {
+    match grug_crypto::ed25519_batch_verify(&prehash_msgs, &sigs, &pks) {
         Ok(()) => Ok(0),
         Err(err) => Ok(err.into_error_code()),
     }


### PR DESCRIPTION
1. Fixes a memory bug related to `Region::build`
2. Rename the input parameter `msgs_hash` to `prehash_msgs`, since this function takes the preimages.