### PR TITLE
Improvements to NonZero

### DIFF
--- a/contracts/taxman/src/execute.rs
+++ b/contracts/taxman/src/execute.rs
@@ -99,7 +99,7 @@ pub fn finalize_fee(ctx: AuthCtx, tx: Tx, outcome: TxOutcome) -> anyhow::Result<
     let charge_msg = if !charge_amount.is_zero() {
         Some(Message::Transfer {
             to: info.config.owner,
-            coins: Coins::one(cfg.fee_denom.clone(), NonZero::new(charge_amount)),
+            coins: Coins::one(cfg.fee_denom.clone(), NonZero::new(charge_amount)?),
         })
     } else {
         None
@@ -108,7 +108,7 @@ pub fn finalize_fee(ctx: AuthCtx, tx: Tx, outcome: TxOutcome) -> anyhow::Result<
     let refund_msg = if !refund_amount.is_zero() {
         Some(Message::Transfer {
             to: tx.sender,
-            coins: Coins::one(cfg.fee_denom, NonZero::new(refund_amount)),
+            coins: Coins::one(cfg.fee_denom, NonZero::new(refund_amount)?),
         })
     } else {
         None

--- a/crates/client/examples/build_genesis.rs
+++ b/crates/client/examples/build_genesis.rs
@@ -47,11 +47,11 @@ fn main() -> anyhow::Result<()> {
             initial_balances: [
                 (
                     account1,
-                    Coins::one("uatom", NonZero::new(Uint128::new(1_000_000))),
+                    Coins::one("uatom", NonZero::new(Uint128::new(1_000_000))?),
                 ),
                 (
                     account2,
-                    Coins::one("uosmo", NonZero::new(Uint128::new(1_000_000))),
+                    Coins::one("uosmo", NonZero::new(Uint128::new(1_000_000))?),
                 ),
             ]
             .into(),

--- a/crates/std/tests/queries.rs
+++ b/crates/std/tests/queries.rs
@@ -40,7 +40,10 @@ mod query_maker {
 #[test]
 fn query_super_smart() {
     let (mut suite, accounts) = TestBuilder::new()
-        .add_account("larry", Coins::one("uusdc", NonZero::new(123_u128)))
+        .add_account(
+            "larry",
+            Coins::one("uusdc", NonZero::new(123_u128).unwrap()),
+        )
         .unwrap()
         .set_chain_id("kebab")
         .set_owner("larry")

--- a/crates/testing/tests/account.rs
+++ b/crates/testing/tests/account.rs
@@ -20,7 +20,7 @@ fn check_tx_and_finalize() -> anyhow::Result<()> {
 
     let transfer_msg = Message::transfer(
         accounts["larry"].address,
-        Coins::one("uatom", NonZero::new(Uint256::from(10_u128))),
+        Coins::one("uatom", NonZero::new(Uint256::from(10_u128))?),
     )?;
 
     // Create a tx to set sequence to 1.
@@ -164,7 +164,7 @@ fn backrunning_works() -> anyhow::Result<()> {
         })?
         .add_account(
             "sender",
-            Coins::one("ugrug", NonZero::new(Uint256::from(50_000_u128))),
+            Coins::one("ugrug", NonZero::new(Uint256::from(50_000_u128))?),
         )?
         .add_account("receiver", Coins::new())?
         .set_owner("sender")?
@@ -174,7 +174,7 @@ fn backrunning_works() -> anyhow::Result<()> {
     suite.transfer(
         &accounts["sender"],
         accounts["receiver"].address,
-        Coins::one("ugrug", NonZero::new(Uint256::from(123_u128))),
+        Coins::one("ugrug", NonZero::new(Uint256::from(123_u128))?),
     )?;
 
     // Receiver should have received ugrug, and sender should have minted bad kids.
@@ -205,7 +205,7 @@ fn backrunning_with_error() -> anyhow::Result<()> {
         })?
         .add_account(
             "sender",
-            Coins::one("ugrug", NonZero::new(Uint256::from(50_000_u128))),
+            Coins::one("ugrug", NonZero::new(Uint256::from(50_000_u128))?),
         )?
         .add_account("receiver", Coins::new())?
         .set_owner("sender")?
@@ -217,7 +217,7 @@ fn backrunning_with_error() -> anyhow::Result<()> {
             &accounts["sender"],
             Message::transfer(
                 accounts["receiver"].address,
-                Coins::one("ugrug", NonZero::new(Uint256::from(123_u128))),
+                Coins::one("ugrug", NonZero::new(Uint256::from(123_u128))?),
             )?,
         )?
         .result

--- a/crates/testing/tests/cron.rs
+++ b/crates/testing/tests/cron.rs
@@ -79,9 +79,9 @@ fn cronjob_works() -> anyhow::Result<()> {
         "cron1",
         &tester::Job {
             receiver: accounts["jake"].address,
-            coin: Coin::new("uatom", NonZero::new(Uint128::new(1))),
+            coin: Coin::new("uatom", NonZero::new(Uint128::new(1))?),
         },
-        Coin::new("uatom", NonZero::new(Uint128::new(3))),
+        Coin::new("uatom", NonZero::new(Uint128::new(3))?),
     )?;
 
     // Block time: 3
@@ -91,9 +91,9 @@ fn cronjob_works() -> anyhow::Result<()> {
         "cron2",
         &tester::Job {
             receiver: accounts["jake"].address,
-            coin: Coin::new("uosmo", NonZero::new(Uint128::new(1))),
+            coin: Coin::new("uosmo", NonZero::new(Uint128::new(1))?),
         },
-        Coin::new("uosmo", NonZero::new(Uint128::new(3))),
+        Coin::new("uosmo", NonZero::new(Uint128::new(3))?),
     )?;
 
     // Block time: 4
@@ -103,9 +103,9 @@ fn cronjob_works() -> anyhow::Result<()> {
         "cron3",
         &tester::Job {
             receiver: accounts["jake"].address,
-            coin: Coin::new("umars", NonZero::new(Uint128::new(1))),
+            coin: Coin::new("umars", NonZero::new(Uint128::new(1))?),
         },
-        Coin::new("umars", NonZero::new(Uint128::new(3))),
+        Coin::new("umars", NonZero::new(Uint128::new(3))?),
     )?;
 
     // Block time: 5

--- a/crates/testing/tests/queries.rs
+++ b/crates/testing/tests/queries.rs
@@ -34,7 +34,7 @@ mod query_maker {
 #[test]
 fn handling_multi_query() -> anyhow::Result<()> {
     let (mut suite, accounts) = TestBuilder::new()
-        .add_account("larry", Coins::one("uusdc", NonZero::new(123_u128)))?
+        .add_account("larry", Coins::one("uusdc", NonZero::new(123_u128)?))?
         .set_chain_id("kebab")
         .set_owner("larry")?
         .build()?;

--- a/crates/testing/tests/taxman.rs
+++ b/crates/testing/tests/taxman.rs
@@ -72,7 +72,7 @@ mod taxman {
         let charge_msg = if !charge_amount.is_zero() {
             Some(Message::transfer(
                 info.config.owner,
-                Coins::one(FEE_DENOM, NonZero::new(charge_amount)),
+                Coins::one(FEE_DENOM, NonZero::new(charge_amount)?),
             )?)
         } else {
             None
@@ -81,7 +81,7 @@ mod taxman {
         let refund_msg = if !refund_amount.is_zero() {
             Some(Message::transfer(
                 tx.sender,
-                Coins::one(FEE_DENOM, NonZero::new(refund_amount)),
+                Coins::one(FEE_DENOM, NonZero::new(refund_amount)?),
             )?)
         } else {
             None
@@ -171,7 +171,10 @@ fn withholding_and_finalizing_fee_works(
         .unwrap()
         .add_account(
             "sender",
-            Coins::one(taxman::FEE_DENOM, NonZero::new(sender_balance_before)),
+            Coins::one(
+                taxman::FEE_DENOM,
+                NonZero::new(sender_balance_before).unwrap(),
+            ),
         )
         .unwrap()
         .add_account("receiver", Coins::new())
@@ -187,7 +190,7 @@ fn withholding_and_finalizing_fee_works(
             gas_limit,
             Message::transfer(
                 accounts["receiver"].address,
-                Coins::one(taxman::FEE_DENOM, NonZero::new(send_amount)),
+                Coins::one(taxman::FEE_DENOM, NonZero::new(send_amount).unwrap()),
             )
             .unwrap(),
         )
@@ -234,7 +237,7 @@ fn finalizing_fee_erroring() {
         .unwrap()
         .add_account(
             "sender",
-            Coins::one(taxman::FEE_DENOM, NonZero::new(30_000_u128)),
+            Coins::one(taxman::FEE_DENOM, NonZero::new(30_000_u128).unwrap()),
         )
         .unwrap()
         .set_owner("owner")

--- a/crates/types/src/bytearray.rs
+++ b/crates/types/src/bytearray.rs
@@ -96,7 +96,7 @@ impl<const N: usize> ser::Serialize for ByteArray<N> {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_some(&BASE64.encode(&self.0))
+        serializer.serialize_str(&BASE64.encode(&self.0))
     }
 }
 

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -151,6 +151,9 @@ pub enum StdError {
     #[error("logarithm of zero")]
     ZeroLog,
 
+    #[error("expecting a non-zero value of type {ty}, got zero")]
+    ZeroValue { ty: &'static str },
+
     #[error("failed to serialize into json! codec: {codec}, type: {ty}, reason: {reason}")]
     Serialize {
         codec: &'static str,
@@ -297,6 +300,12 @@ impl StdError {
 
     pub fn zero_log() -> Self {
         Self::ZeroLog
+    }
+
+    pub fn zero_value<T>() -> Self {
+        Self::ZeroValue {
+            ty: type_name::<T>(),
+        }
     }
 
     pub fn negative_mul<A, B>(a: A, b: B) -> Self

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -15,6 +15,7 @@ mod hashers;
 mod imports;
 mod macros;
 mod math;
+mod non_zero;
 mod query;
 mod response;
 mod result;
@@ -26,8 +27,8 @@ mod utils;
 
 pub use {
     address::*, app::*, bank::*, binary::*, builder::*, bytearray::*, coin::*, context::*, db::*,
-    empty::*, error::*, event::*, hash::*, hashers::*, imports::*, math::*, query::*, response::*,
-    result::*, serializers::*, testing::*, time::*, tx::*, utils::*,
+    empty::*, error::*, event::*, hash::*, hashers::*, imports::*, math::*, non_zero::*, query::*,
+    response::*, result::*, serializers::*, testing::*, time::*, tx::*, utils::*,
 };
 
 /// Represents any valid JSON value, including numbers, booleans, strings,

--- a/crates/types/src/math/traits.rs
+++ b/crates/types/src/math/traits.rs
@@ -1,41 +1,10 @@
 use {
     crate::{
         grow_be_uint, grow_le_uint, impl_bytable_bnum, impl_bytable_std, impl_integer_number,
-        impl_number_const, StdError, StdResult, Uint,
+        impl_number_const, NonZero, StdError, StdResult, Uint,
     },
     bnum::types::{U256, U512},
-    std::any::type_name,
 };
-
-// ----------------------------------- types -----------------------------------
-
-/// A wrapper over a number that ensures it is non-zero.
-pub struct NonZero<T>(T);
-
-impl<T> NonZero<T>
-where
-    T: Number,
-{
-    /// Create a new non-zero wrapper. Panic if a zero is provided.
-    pub fn new(inner: T) -> Self {
-        if inner.is_zero() {
-            panic!(
-                "expecting a non-zero number, got {}::ZERO",
-                type_name::<T>()
-            );
-        }
-        Self(inner)
-    }
-}
-
-impl<T> NonZero<T> {
-    /// Consume the wrapper, return the wrapped number.
-    pub fn into_inner(self) -> T {
-        self.0
-    }
-}
-
-// ---------------------------------- traits -----------------------------------
 
 /// Describes a type that wraps another type.
 ///

--- a/crates/types/src/math/traits.rs
+++ b/crates/types/src/math/traits.rs
@@ -200,15 +200,9 @@ impl_integer_number!(U512);
 #[cfg(test)]
 mod tests {
     use {
-        crate::{Bytable, NonZero, Number, NumberConst, Uint128, Uint256},
+        crate::{Bytable, Number, NumberConst, Uint128, Uint256},
         proptest::{array::uniform32, prelude::*},
     };
-
-    #[test]
-    #[should_panic]
-    fn non_zero_works() {
-        let _ = NonZero::new(Uint128::ZERO);
-    }
 
     proptest! {
         /// Ensure the bytable methods work for `Uint128`.

--- a/crates/types/src/math/udec.rs
+++ b/crates/types/src/math/udec.rs
@@ -262,7 +262,9 @@ where
     }
 
     fn denominator() -> NonZero<Uint<U>> {
-        NonZero::new(Self::decimal_fraction())
+        // We know the decimal fraction is non-zero, because it's defined as a
+        // power (10^S), so we can safely wrap it in `NonZero` without checking.
+        NonZero(Self::decimal_fraction())
     }
 }
 

--- a/crates/types/src/non_zero.rs
+++ b/crates/types/src/non_zero.rs
@@ -1,0 +1,145 @@
+use {
+    crate::{Number, StdError, StdResult},
+    borsh::{BorshDeserialize, BorshSerialize},
+    serde::{de, de::Error, Serialize},
+    std::{
+        fmt,
+        fmt::Display,
+        io,
+        ops::{Deref, DerefMut},
+    },
+};
+
+/// A wrapper over a number that ensures it is non-zero.
+#[derive(Serialize, BorshSerialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NonZero<T>(pub(crate) T);
+
+impl<T> NonZero<T>
+where
+    T: Number,
+{
+    /// Create a new non-zero wrapper. Panic if a zero is provided.
+    pub fn new(inner: T) -> StdResult<Self> {
+        if inner.is_zero() {
+            return Err(StdError::zero_value::<Self>());
+        }
+
+        Ok(Self(inner))
+    }
+}
+
+impl<T> NonZero<T> {
+    /// Consume the wrapper, return the wrapped number.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> AsRef<T> for NonZero<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> AsMut<T> for NonZero<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> Deref for NonZero<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for NonZero<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> Display for NonZero<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'de, T> de::Deserialize<'de> for NonZero<T>
+where
+    T: Number + de::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let inner = T::deserialize(deserializer)?;
+
+        // We assert the number is non-zero here with `NonZero::new`.
+        NonZero::new(inner).map_err(D::Error::custom)
+    }
+}
+
+impl<T> BorshDeserialize for NonZero<T>
+where
+    T: Number + BorshDeserialize,
+{
+    fn deserialize_reader<R>(reader: &mut R) -> io::Result<Self>
+    where
+        R: io::Read,
+    {
+        let inner = borsh::from_reader(reader)?;
+
+        // We assert the number is non-zero here with `NonZero::new`.
+        NonZero::new(inner).map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+    }
+}
+
+// ----------------------------------- tests -----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::{BorshDeExt, BorshSerExt, JsonDeExt, NonZero, NumberConst, StdError, Uint128};
+
+    // The expect error is a `StdError::Deserialize` where the `reason` is a
+    // `StdError::ZeroValue`.
+    fn assert_is_non_zero_err<T>(err: StdError) {
+        assert!(matches!(
+            err,
+            StdError::Deserialize { reason, .. } if reason == StdError::zero_value::<T>().to_string()
+        ));
+    }
+
+    #[test]
+    fn deserializing_from_json() {
+        let res = "123".deserialize_json::<NonZero<u32>>().unwrap();
+        assert_eq!(res, NonZero(123));
+
+        let err = "0".deserialize_json::<NonZero<u32>>().unwrap_err();
+        assert_is_non_zero_err::<NonZero<u32>>(err);
+
+        let res = "\"123\"".deserialize_json::<NonZero<Uint128>>().unwrap();
+        assert_eq!(res, NonZero(Uint128::new(123)));
+
+        let err = "\"0\"".deserialize_json::<NonZero<Uint128>>().unwrap_err();
+        assert_is_non_zero_err::<NonZero<Uint128>>(err);
+    }
+
+    #[test]
+    fn deserialize_from_borsh() {
+        let good = NonZero(Uint128::new(123)).to_borsh_vec().unwrap();
+        let res = good.deserialize_borsh::<NonZero<Uint128>>().unwrap();
+        assert_eq!(res, NonZero(Uint128::new(123)));
+
+        // Construct an illegal `NonZero` with a zero inside.
+        // This is only possible here because the inner value is `pub(crate)`.
+        let bad = NonZero(Uint128::ZERO).to_borsh_vec().unwrap();
+        let err = bad.deserialize_borsh::<NonZero<Uint128>>().unwrap_err();
+        assert_is_non_zero_err::<NonZero<Uint128>>(err);
+    }
+}

--- a/crates/types/src/non_zero.rs
+++ b/crates/types/src/non_zero.rs
@@ -18,7 +18,7 @@ impl<T> NonZero<T>
 where
     T: Number,
 {
-    /// Create a new non-zero wrapper. Panic if a zero is provided.
+    /// Attempt to create a new non-zero wrapper. Error if a zero is provided.
     pub fn new(inner: T) -> StdResult<Self> {
         if inner.is_zero() {
             return Err(StdError::zero_value::<Self>());

--- a/crates/vm/rust/tests/transfer.rs
+++ b/crates/vm/rust/tests/transfer.rs
@@ -8,7 +8,7 @@ const DENOM: &str = "ugrug";
 #[test]
 fn transfers() -> anyhow::Result<()> {
     let (mut suite, accounts) = TestBuilder::new()
-        .add_account("sender", Coins::one(DENOM, NonZero::new(100_u128)))?
+        .add_account("sender", Coins::one(DENOM, NonZero::new(100_u128)?))?
         .add_account("receiver", Coins::new())?
         .set_owner("sender")?
         .build()?;
@@ -26,19 +26,19 @@ fn transfers() -> anyhow::Result<()> {
         .send_messages(&accounts["sender"], vec![
             Message::Transfer {
                 to: accounts["receiver"].address,
-                coins: Coins::one(DENOM, NonZero::new(10_u128)),
+                coins: Coins::one(DENOM, NonZero::new(10_u128)?),
             },
             Message::Transfer {
                 to: accounts["receiver"].address,
-                coins: Coins::one(DENOM, NonZero::new(15_u128)),
+                coins: Coins::one(DENOM, NonZero::new(15_u128)?),
             },
             Message::Transfer {
                 to: accounts["receiver"].address,
-                coins: Coins::one(DENOM, NonZero::new(20_u128)),
+                coins: Coins::one(DENOM, NonZero::new(20_u128)?),
             },
             Message::Transfer {
                 to: accounts["receiver"].address,
-                coins: Coins::one(DENOM, NonZero::new(25_u128)),
+                coins: Coins::one(DENOM, NonZero::new(25_u128)?),
             },
         ])?
         .result

--- a/crates/vm/wasm/tests/tester.rs
+++ b/crates/vm/wasm/tests/tester.rs
@@ -29,7 +29,7 @@ fn read_wasm_file(filename: &str) -> io::Result<Binary> {
 fn setup_test() -> anyhow::Result<(TestSuite<WasmVm>, TestAccounts, Addr)> {
     let (mut suite, accounts) = TestBuilder::new_with_vm(WasmVm::new(WASM_CACHE_CAPACITY))
         .add_account("owner", Coins::new())?
-        .add_account("sender", Coins::one(DENOM, NonZero::new(32_100_000_u128)))?
+        .add_account("sender", Coins::one(DENOM, NonZero::new(32_100_000_u128)?))?
         .set_owner("owner")?
         .set_fee_rate(Udec128::from_str(FEE_RATE)?)
         .build()?;

--- a/crates/vm/wasm/tests/transfer.rs
+++ b/crates/vm/wasm/tests/transfer.rs
@@ -13,7 +13,7 @@ const FEE_RATE: &str = "0.1";
 fn transfers() -> anyhow::Result<()> {
     let (mut suite, accounts) = TestBuilder::new_with_vm(WasmVm::new(WASM_CACHE_CAPACITY))
         .add_account("owner", Coins::new())?
-        .add_account("sender", Coins::one(DENOM, NonZero::new(300_000_u128)))?
+        .add_account("sender", Coins::one(DENOM, NonZero::new(300_000_u128)?))?
         .add_account("receiver", Coins::new())?
         .set_owner("owner")?
         .set_fee_denom(DENOM)
@@ -33,19 +33,19 @@ fn transfers() -> anyhow::Result<()> {
     let outcome = suite.send_messages_with_gas(&accounts["sender"], 2_500_000, vec![
         Message::Transfer {
             to: accounts["receiver"].address,
-            coins: Coins::one(DENOM, NonZero::new(10_u128)),
+            coins: Coins::one(DENOM, NonZero::new(10_u128)?),
         },
         Message::Transfer {
             to: accounts["receiver"].address,
-            coins: Coins::one(DENOM, NonZero::new(15_u128)),
+            coins: Coins::one(DENOM, NonZero::new(15_u128)?),
         },
         Message::Transfer {
             to: accounts["receiver"].address,
-            coins: Coins::one(DENOM, NonZero::new(20_u128)),
+            coins: Coins::one(DENOM, NonZero::new(20_u128)?),
         },
         Message::Transfer {
             to: accounts["receiver"].address,
-            coins: Coins::one(DENOM, NonZero::new(25_u128)),
+            coins: Coins::one(DENOM, NonZero::new(25_u128)?),
         },
     ])?;
 
@@ -86,7 +86,7 @@ fn transfers() -> anyhow::Result<()> {
 fn transfers_with_insufficient_gas_limit() -> anyhow::Result<()> {
     let (mut suite, accounts) = TestBuilder::new_with_vm(WasmVm::new(WASM_CACHE_CAPACITY))
         .add_account("owner", Coins::new())?
-        .add_account("sender", Coins::one(DENOM, NonZero::new(200_000_u128)))?
+        .add_account("sender", Coins::one(DENOM, NonZero::new(200_000_u128)?))?
         .add_account("receiver", Coins::new())?
         .set_owner("owner")?
         .set_fee_rate(Udec128::from_str(FEE_RATE)?)
@@ -102,7 +102,7 @@ fn transfers_with_insufficient_gas_limit() -> anyhow::Result<()> {
     // the error message contains the word "gas".
     let outcome = suite.send_message_with_gas(&accounts["sender"], 100_000, Message::Transfer {
         to: accounts["receiver"].address,
-        coins: Coins::one(DENOM, NonZero::new(10_u128)),
+        coins: Coins::one(DENOM, NonZero::new(10_u128)?),
     })?;
 
     outcome.result.should_fail();


### PR DESCRIPTION
`NonZero::new` method now errors instead of panics in case a zero value is provided.

Also, implement necessary traits such that `NonZero<T>` can be used in messages or storage.
