### PR TITLE
Simplify `Udec`

### DIFF
--- a/crates/storage/src/key.rs
+++ b/crates/storage/src/key.rs
@@ -405,7 +405,7 @@ where
     }
 }
 
-impl<T, const S: u32> PrimaryKey for Udec<T, S>
+impl<T> PrimaryKey for Udec<T>
 where
     Uint<T>: PrimaryKey<Output = Uint<T>>,
 {
@@ -637,7 +637,7 @@ where
     }
 }
 
-impl<T, const S: u32> Prefixer for Udec<T, S>
+impl<T> Prefixer for Udec<T>
 where
     Uint<T>: PrimaryKey<Output = Uint<T>>,
 {

--- a/crates/types/src/macros.rs
+++ b/crates/types/src/macros.rs
@@ -244,12 +244,11 @@ macro_rules! generate_decimal {
     (
         name = $name:ident,
         inner_type = $inner:ty,
-        decimal_places = $decimal_places:expr,
         from_dec = [$($from:ty),*],
         doc = $doc:literal,
     ) => {
         #[doc = $doc]
-        pub type $name = Udec<$inner, $decimal_places>;
+        pub type $name = Udec<$inner>;
 
         // Ex: From<U256> for Udec256
         impl From<$inner> for $name {
@@ -806,7 +805,7 @@ macro_rules! impl_number {
 
     // Udec Self
     (impl Udec with $imp:ident, $method:ident for $t:ty where sub fn $sub_method:ident) => {
-        impl<U, const S: u32> std::ops::$imp for $t
+        impl<U> std::ops::$imp for $t
         where
             Self: Number,
         {
@@ -869,7 +868,7 @@ macro_rules! impl_assign_number {
 
     // Udec
     (impl Udec with $imp:ident, $method:ident for $t:ty where sub fn $sub_method:ident) => {
-        impl<U, const S: u32> std::ops::$imp for $t
+        impl<U> std::ops::$imp for $t
         where
             Self: Number + Copy,
         {
@@ -990,67 +989,9 @@ macro_rules! forward_ref_binop_typed {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! forward_ref_binop_decimal {
-    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
-        impl<U, const S: u32> std::ops::$imp<$u> for &'_ $t
-        where
-            $t: std::ops::$imp<$u> + Copy,
-        {
-            type Output = <$t as std::ops::$imp<$u>>::Output;
-
-            #[inline]
-            fn $method(self, other: $u) -> <$t as std::ops::$imp<$u>>::Output {
-                std::ops::$imp::$method(*self, other)
-            }
-        }
-
-        impl<U, const S: u32> std::ops::$imp<&$u> for $t
-        where
-            $t: std::ops::$imp<$u> + Copy,
-        {
-            type Output = <$t as std::ops::$imp<$u>>::Output;
-
-            #[inline]
-            fn $method(self, other: &$u) -> <$t as std::ops::$imp<$u>>::Output {
-                std::ops::$imp::$method(self, *other)
-            }
-        }
-
-        impl<U, const S: u32> std::ops::$imp<&$u> for &'_ $t
-        where
-            $t: std::ops::$imp<$u> + Copy,
-        {
-            type Output = <$t as std::ops::$imp<$u>>::Output;
-
-            #[inline]
-            fn $method(self, other: &$u) -> <$t as std::ops::$imp<$u>>::Output {
-                std::ops::$imp::$method(*self, *other)
-            }
-        }
-    };
-}
-
-#[macro_export]
-#[doc(hidden)]
 macro_rules! forward_ref_op_assign_typed {
     (impl<$($gen:tt),*> $imp:ident, $method:ident for $t:ty, $u:ty) => {
         impl <$($gen),*> std::ops::$imp<&$u> for $t
-        where
-            $t: std::ops::$imp<$u> + Copy,
-        {
-            #[inline]
-            fn $method(&mut self, other: &$u) {
-                std::ops::$imp::$method(self, *other);
-            }
-        }
-    };
-}
-
-#[macro_export]
-#[doc(hidden)]
-macro_rules! forward_ref_op_assign_decimal {
-    (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
-        impl<U, const S: u32> std::ops::$imp<&$u> for $t
         where
             $t: std::ops::$imp<$u> + Copy,
         {

--- a/crates/types/src/math/udec.rs
+++ b/crates/types/src/math/udec.rs
@@ -31,7 +31,7 @@ impl<U> Udec<U> {
     /// Since we use `u128` here, whose maximum value is 3.4e+38, it's possible
     /// to have at most 37 decimal places. Going higher would cause this `pow`
     /// calculation to overflow, resulting in a compile time error.
-    pub const DECIMAL_FRACTION: u128 = 10u128.pow(Self::DECIMAL_PLACES);
+    pub const DECIMAL_FRACTION: u64 = 10u64.pow(Self::DECIMAL_PLACES);
     /// Number of decimal digits to be interpreted as decimal places.
     pub const DECIMAL_PLACES: u32 = 18;
 
@@ -71,7 +71,7 @@ where
 
 impl<U> Udec<U>
 where
-    Uint<U>: From<u128>,
+    Uint<U>: From<u64>,
 {
     // This can't be made `const` because of the `into` casting isn't constant.
     pub fn one() -> Self {
@@ -85,7 +85,7 @@ where
 
 impl<U> Udec<U>
 where
-    Uint<U>: Number + From<u128>,
+    Uint<U>: Number + From<u64>,
 {
     /// Create a new [`Udec`] adding decimal places.
     ///
@@ -118,7 +118,7 @@ where
 
 impl<U> Udec<U>
 where
-    Uint<U>: NumberConst + Number + From<u128>,
+    Uint<U>: NumberConst + Number + From<u64>,
 {
     pub fn checked_from_atomics(
         atomics: impl Into<Uint<U>>,
@@ -155,7 +155,7 @@ where
 
 impl<U> Udec<U>
 where
-    Uint<U>: MultiplyRatio + From<u128>,
+    Uint<U>: MultiplyRatio + From<u64>,
 {
     pub fn checked_from_ratio(
         numerator: impl Into<Uint<U>>,
@@ -198,7 +198,7 @@ where
 impl<U> Decimal for Udec<U>
 where
     U: Copy + PartialEq,
-    Uint<U>: Number + From<u128>,
+    Uint<U>: Number + From<u64>,
 {
     fn checked_floor(self) -> StdResult<Self> {
         // There are two ways to floor:
@@ -239,7 +239,7 @@ impl<U> Sign for Udec<U> {
 
 impl<U> Fraction<U> for Udec<U>
 where
-    Uint<U>: Number + Copy + From<u128>,
+    Uint<U>: Number + Copy + From<u64>,
 {
     fn numerator(&self) -> Uint<U> {
         self.0
@@ -255,7 +255,7 @@ where
 impl<U> Number for Udec<U>
 where
     U: NumberConst + Number + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + Display + From<u128>,
+    Uint<U>: NextNumber + Display + From<u64>,
     <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
 {
     fn is_zero(&self) -> bool {
@@ -374,7 +374,7 @@ where
 impl<U> Display for Udec<U>
 where
     U: Display,
-    Uint<U>: Number + Copy + From<u128>,
+    Uint<U>: Number + Copy + From<u64>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let decimals = Self::DECIMAL_FRACTION.into();
@@ -400,7 +400,7 @@ where
 
 impl<U> FromStr for Udec<U>
 where
-    Uint<U>: NumberConst + Number + Display + FromStr + From<u128>,
+    Uint<U>: NumberConst + Number + Display + FromStr + From<u64>,
 {
     type Err = StdError;
 


### PR DESCRIPTION
Removed `const S: u32` as generic param for `Udec, hardcoded to `18`