### PR TITLE
M1 - Simplify `Udec`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,14 +111,14 @@ When implementing methods that involve generic types, the relevant trait bounds 
 Trait bound should be _direct_. See the following example on what this means:
 
 ```diff
-impl<U, const S: u32> FromStr for Decimal<U, S>
+impl<U> FromStr for Decimal<U, S>
 where
     Uint<U>: NumberConst + Number + Display + FromStr + From<u128>,
 {
     // ...
 }
 
-impl<'de, U, const S: u32> de::Visitor<'de> for DecimalVisitor<U, S>
+impl<'de, U> de::Visitor<'de> for DecimalVisitor<U, S>
 where
 -   Uint<U>: NumberConst + Number + Display + FromStr + From<u128>,
 +   Decimal<U, S>: FromStr,

--- a/crates/math/src/fixed_point.rs
+++ b/crates/math/src/fixed_point.rs
@@ -1,7 +1,10 @@
-use bnum::types::U256;
+use {
+    crate::{Udec128, Udec256, Uint, Uint128, Uint256},
+    bnum::types::U256,
+};
 
-use crate::{Udec128, Udec256, Uint, Uint128, Uint256};
-
+/// Describes a [fixed-point decimal](https://en.wikipedia.org/wiki/Fixed-point_arithmetic)
+/// number.
 pub trait FixedPoint<U> {
     /// Ratio between the inner integer value and the decimal value it
     /// represents.
@@ -11,14 +14,12 @@ pub trait FixedPoint<U> {
     const DECIMAL_PLACES: u32;
 }
 
-macro_rules! impl_fixed_point {
-    ($t:ty => $u:ty, $constructor:expr, $dp:expr) => {
-        impl FixedPoint<$u> for $t {
-            const DECIMAL_FRACTION: Uint<$u> = $constructor(10_u128.pow($dp));
-            const DECIMAL_PLACES: u32 = $dp;
-        }
-    };
+impl FixedPoint<u128> for Udec128 {
+    const DECIMAL_FRACTION: Uint128 = Uint128::new(1_000_000_000_000_000_000);
+    const DECIMAL_PLACES: u32 = 18;
 }
 
-impl_fixed_point!(Udec128 => u128, Uint128::new, 18);
-impl_fixed_point!(Udec256 => U256, Uint256::new_from_u128, 18);
+impl FixedPoint<U256> for Udec256 {
+    const DECIMAL_FRACTION: Uint256 = Uint256::new_from_u128(1_000_000_000_000_000_000);
+    const DECIMAL_PLACES: u32 = 18;
+}

--- a/crates/math/src/fixed_point.rs
+++ b/crates/math/src/fixed_point.rs
@@ -1,0 +1,24 @@
+use bnum::types::U256;
+
+use crate::{Udec128, Udec256, Uint, Uint128, Uint256};
+
+pub trait FixedPoint<U> {
+    /// Ratio between the inner integer value and the decimal value it
+    /// represents.
+    const DECIMAL_FRACTION: Uint<U>;
+
+    /// Number of decimal digits to be interpreted as decimal places.
+    const DECIMAL_PLACES: u32;
+}
+
+macro_rules! impl_fixed_point {
+    ($t:ty => $u:ty, $constructor:expr, $dp:expr) => {
+        impl FixedPoint<$u> for $t {
+            const DECIMAL_FRACTION: Uint<$u> = $constructor(10_u128.pow($dp));
+            const DECIMAL_PLACES: u32 = $dp;
+        }
+    };
+}
+
+impl_fixed_point!(Udec128 => u128, Uint128::new, 18);
+impl_fixed_point!(Udec256 => U256, Uint256::new_from_u128, 18);

--- a/crates/math/src/lib.rs
+++ b/crates/math/src/lib.rs
@@ -1,6 +1,7 @@
 mod bytable;
 mod decimal;
 mod error;
+mod fixed_point;
 mod fraction;
 mod inner;
 mod integer;
@@ -15,6 +16,7 @@ mod uint;
 mod utils;
 
 pub use {
-    bytable::*, decimal::*, error::*, fraction::*, inner::*, integer::*, multiply_fraction::*,
-    multiply_ratio::*, next::*, number::*, number_const::*, sign::*, udec::*, uint::*,
+    bytable::*, decimal::*, error::*, fixed_point::*, fraction::*, inner::*, integer::*,
+    multiply_fraction::*, multiply_ratio::*, next::*, number::*, number_const::*, sign::*, udec::*,
+    uint::*,
 };

--- a/crates/math/src/udec.rs
+++ b/crates/math/src/udec.rs
@@ -47,7 +47,7 @@ impl<U> Udec<U> {
 impl<U> Udec<U>
 where
     Self: FixedPoint<U>,
-    Uint<U>: NumberConst + Number + From<u128>,
+    Uint<U>: NumberConst + Number,
 {
     pub fn checked_from_atomics<T>(atomics: T, decimal_places: u32) -> MathResult<Self>
     where
@@ -85,7 +85,7 @@ where
 impl<U> Udec<U>
 where
     Self: FixedPoint<U>,
-    Uint<U>: MultiplyRatio + From<u64>,
+    Uint<U>: MultiplyRatio,
 {
     pub fn checked_from_ratio<N, D>(numerator: N, denominator: D) -> MathResult<Self>
     where
@@ -130,9 +130,7 @@ where
 impl<U> Decimal for Udec<U>
 where
     Self: FixedPoint<U>,
-
     U: Number + Copy + PartialEq,
-    Uint<U>: From<u64>,
 {
     fn checked_floor(self) -> MathResult<Self> {
         // There are two ways to floor:
@@ -175,7 +173,6 @@ impl<U> Fraction<U> for Udec<U>
 where
     Self: FixedPoint<U>,
     U: Number + Copy,
-    Uint<U>: From<u64>,
 {
     fn numerator(&self) -> Uint<U> {
         self.0
@@ -190,7 +187,7 @@ impl<U> Number for Udec<U>
 where
     Self: FixedPoint<U> + NumberConst,
     U: NumberConst + Number + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + Display + From<u64>,
+    Uint<U>: NextNumber + Display,
     <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
 {
     fn is_zero(&self) -> bool {
@@ -304,7 +301,7 @@ impl<U> Display for Udec<U>
 where
     Self: FixedPoint<U>,
     U: Number + Display,
-    Uint<U>: Copy + From<u64>,
+    Uint<U>: Copy,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let decimals = Self::DECIMAL_FRACTION;
@@ -331,7 +328,7 @@ where
 impl<U> FromStr for Udec<U>
 where
     Self: FixedPoint<U>,
-    Uint<U>: NumberConst + Number + Display + FromStr + From<u64>,
+    Uint<U>: NumberConst + Number + Display + FromStr,
 {
     type Err = MathError;
 

--- a/crates/math/src/udec.rs
+++ b/crates/math/src/udec.rs
@@ -559,8 +559,7 @@ macro_rules! generate_decimal {
             ///     std::str::FromStr,
             /// };
             ///
-            /// let uint = Uint128::new(100);
-            /// let decimal = Udec128::new(uint);
+            /// let decimal = Udec128::new(100);
             /// assert_eq!(decimal, Udec128::from_str("100.0").unwrap());
             /// ```
             pub const fn new(x: u128) -> Self {

--- a/crates/math/src/udec.rs
+++ b/crates/math/src/udec.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        Decimal, Fraction, Inner, MathError, MathResult, MultiplyRatio, NextNumber, Number,
-        NumberConst, Sign, Uint,
+        Decimal, FixedPoint, Fraction, Inner, MathError, MathResult, MultiplyRatio, NextNumber,
+        Number, NumberConst, Sign, Uint, Uint128, Uint256,
     },
     bnum::types::U256,
     borsh::{BorshDeserialize, BorshSerialize},
@@ -23,16 +23,6 @@ use {
 pub struct Udec<U>(pub(crate) Uint<U>);
 
 impl<U> Udec<U> {
-    /// Ratio between the inner integer value and the decimal value it
-    /// represents.
-    ///
-    /// Since we use `u128` here, whose maximum value is 3.4e+38, it's possible
-    /// to have at most 37 decimal places. Going higher would cause this `pow`
-    /// calculation to overflow, resulting in a compile time error.
-    pub const DECIMAL_FRACTION: u64 = 10u64.pow(Self::DECIMAL_PLACES);
-    /// Number of decimal digits to be interpreted as decimal places.
-    pub const DECIMAL_PLACES: u32 = 18;
-
     /// Create a new [`Udec`] _without_ adding decimal places.
     ///
     /// ```rust
@@ -54,69 +44,9 @@ impl<U> Udec<U> {
     }
 }
 
-impl<U> NumberConst for Udec<U>
-where
-    Uint<U>: NumberConst,
-{
-    const MAX: Self = Self(Uint::MAX);
-    const MIN: Self = Self(Uint::MIN);
-    // TODO: These two (one and ten) can be confusing. How can we make this
-    // clear for users?
-    const ONE: Self = Self(Uint::ONE);
-    const TEN: Self = Self(Uint::TEN);
-    const ZERO: Self = Self(Uint::ZERO);
-}
-
 impl<U> Udec<U>
 where
-    Uint<U>: From<u64>,
-{
-    // This can't be made `const` because of the `into` casting isn't constant.
-    pub fn one() -> Self {
-        Self(Self::decimal_fraction())
-    }
-
-    pub fn decimal_fraction() -> Uint<U> {
-        Self::DECIMAL_FRACTION.into()
-    }
-}
-
-impl<U> Udec<U>
-where
-    U: Number,
-    Uint<U>: From<u64>,
-{
-    /// Create a new [`Udec`] adding decimal places.
-    ///
-    /// ```rust
-    /// use {
-    ///     grug_math::{Udec128, Uint128},
-    ///     std::str::FromStr,
-    /// };
-    ///
-    /// let uint = Uint128::new(100);
-    /// let decimal = Udec128::new(uint);
-    /// assert_eq!(decimal, Udec128::from_str("100.0").unwrap());
-    /// ```
-    pub fn new(value: impl Into<Uint<U>>) -> Self {
-        Self(value.into() * Self::decimal_fraction())
-    }
-
-    pub fn new_percent(x: impl Into<Uint<U>>) -> Self {
-        Self(x.into() * (Self::DECIMAL_FRACTION / 100).into())
-    }
-
-    pub fn new_permille(x: impl Into<Uint<U>>) -> Self {
-        Self(x.into() * (Self::DECIMAL_FRACTION / 1_000).into())
-    }
-
-    pub fn new_bps(x: impl Into<Uint<U>>) -> Self {
-        Self(x.into() * (Self::DECIMAL_FRACTION / 10_000).into())
-    }
-}
-
-impl<U> Udec<U>
-where
+    Self: FixedPoint<U>,
     Uint<U>: NumberConst + Number + From<u128>,
 {
     pub fn checked_from_atomics<T>(atomics: T, decimal_places: u32) -> MathResult<Self>
@@ -154,6 +84,7 @@ where
 
 impl<U> Udec<U>
 where
+    Self: FixedPoint<U>,
     Uint<U>: MultiplyRatio + From<u64>,
 {
     pub fn checked_from_ratio<N, D>(numerator: N, denominator: D) -> MathResult<Self>
@@ -198,6 +129,8 @@ where
 
 impl<U> Decimal for Udec<U>
 where
+    Self: FixedPoint<U>,
+
     U: Number + Copy + PartialEq,
     Uint<U>: From<u64>,
 {
@@ -211,7 +144,7 @@ where
         // This flooring operation in fact can never fail, because flooring an
         // unsigned decimal goes down to 0 at most. However, flooring a _signed_
         // decimal may underflow.
-        Ok(Self(self.0 - self.0.checked_rem(Self::decimal_fraction())?))
+        Ok(Self(self.0 - self.0.checked_rem(Self::DECIMAL_FRACTION)?))
     }
 
     fn checked_ceil(self) -> MathResult<Self> {
@@ -219,7 +152,7 @@ where
         if floor == self {
             Ok(floor)
         } else {
-            floor.0.checked_add(Self::decimal_fraction()).map(Self)
+            floor.0.checked_add(Self::DECIMAL_FRACTION).map(Self)
         }
     }
 }
@@ -240,6 +173,7 @@ impl<U> Sign for Udec<U> {
 
 impl<U> Fraction<U> for Udec<U>
 where
+    Self: FixedPoint<U>,
     U: Number + Copy,
     Uint<U>: From<u64>,
 {
@@ -248,12 +182,13 @@ where
     }
 
     fn denominator() -> Uint<U> {
-        Self::decimal_fraction()
+        Self::DECIMAL_FRACTION
     }
 }
 
 impl<U> Number for Udec<U>
 where
+    Self: FixedPoint<U> + NumberConst,
     U: NumberConst + Number + Copy + PartialEq + PartialOrd + Display,
     Uint<U>: NextNumber + Display + From<u64>,
     <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
@@ -274,7 +209,7 @@ where
         let next_result = self
             .0
             .checked_full_mul(*other.numerator())?
-            .checked_div(Self::decimal_fraction().into())?;
+            .checked_div(Self::DECIMAL_FRACTION.into())?;
         next_result
             .try_into()
             .map(Self)
@@ -291,10 +226,10 @@ where
 
     fn checked_pow(mut self, mut exp: u32) -> MathResult<Self> {
         if exp == 0 {
-            return Ok(Self::one());
+            return Ok(Self::ONE);
         }
 
-        let mut y = Udec::one();
+        let mut y = Udec::ONE;
         while exp > 1 {
             if exp % 2 == 0 {
                 self = self.checked_mul(self)?;
@@ -367,11 +302,12 @@ where
 
 impl<U> Display for Udec<U>
 where
+    Self: FixedPoint<U>,
     U: Number + Display,
     Uint<U>: Copy + From<u64>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let decimals = Self::DECIMAL_FRACTION.into();
+        let decimals = Self::DECIMAL_FRACTION;
         let whole = (self.0) / decimals;
         let fractional = (self.0).checked_rem(decimals).unwrap();
 
@@ -394,6 +330,7 @@ where
 
 impl<U> FromStr for Udec<U>
 where
+    Self: FixedPoint<U>,
     Uint<U>: NumberConst + Number + Display + FromStr + From<u64>,
 {
     type Err = MathError;
@@ -412,7 +349,7 @@ where
             .unwrap() // split always returns at least one element
             .parse::<Uint<U>>()
             .map_err(|_| MathError::parse_number::<Self, _, _>(input, "error parsing whole"))?
-            .checked_mul(Self::decimal_fraction())
+            .checked_mul(Self::DECIMAL_FRACTION)
             .map_err(|_| MathError::parse_number::<Self, _, _>(input, "value too big"))?;
 
         if let Some(fractional_part) = parts_iter.next() {
@@ -514,9 +451,7 @@ where
 
 impl<U> Add for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number,
 {
     type Output = Self;
 
@@ -527,9 +462,7 @@ where
 
 impl<U> Sub for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number,
 {
     type Output = Self;
 
@@ -540,9 +473,7 @@ where
 
 impl<U> Mul for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number,
 {
     type Output = Self;
 
@@ -553,9 +484,7 @@ where
 
 impl<U> Div for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number,
 {
     type Output = Self;
 
@@ -566,9 +495,7 @@ where
 
 impl<U> AddAssign for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number + Copy,
 {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
@@ -577,9 +504,7 @@ where
 
 impl<U> SubAssign for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number + Copy,
 {
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
@@ -588,9 +513,7 @@ where
 
 impl<U> MulAssign for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number + Copy,
 {
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
@@ -599,9 +522,7 @@ where
 
 impl<U> DivAssign for Udec<U>
 where
-    U: Number + NumberConst + Copy + PartialEq + PartialOrd + Display,
-    Uint<U>: NextNumber + From<u64>,
-    <Uint<U> as NextNumber>::Next: Number + Copy + ToString,
+    Self: Number + Copy,
 {
     fn div_assign(&mut self, rhs: Self) {
         *self = *self / rhs;
@@ -612,13 +533,51 @@ where
 
 macro_rules! generate_decimal {
     (
-        name           = $name:ident,
-        inner_type     = $inner:ty,
-        from_dec       = [$($from:ty),*],
-        doc            = $doc:literal,
+        name              = $name:ident,
+        inner_type        = $inner:ty,
+        inner_constructor = $constructor:expr,
+        from_dec          = [$($from:ty),*],
+        doc               = $doc:literal,
     ) => {
         #[doc = $doc]
         pub type $name = Udec<$inner>;
+
+        impl NumberConst for $name {
+            const MAX: Self = Self(Uint::MAX);
+            const MIN: Self = Self(Uint::MIN);
+            const ONE: Self = Self(Self::DECIMAL_FRACTION);
+            const TEN: Self = Self($constructor(10_u128.pow(Self::DECIMAL_PLACES)));
+            const ZERO: Self = Self(Uint::ZERO);
+        }
+
+        impl $name {
+            /// Create a new [`Udec`] adding decimal places.
+            ///
+            /// ```rust
+            /// use {
+            ///     grug_math::{Udec128, Uint128},
+            ///     std::str::FromStr,
+            /// };
+            ///
+            /// let uint = Uint128::new(100);
+            /// let decimal = Udec128::new(uint);
+            /// assert_eq!(decimal, Udec128::from_str("100.0").unwrap());
+            /// ```
+            pub const fn new(x: u128) -> Self {
+                Self($constructor(x * 10_u128.pow(Self::DECIMAL_PLACES)))
+            }
+            pub const fn new_percent(x: u128) -> Self {
+                Self($constructor(x * 10_u128.pow(Self::DECIMAL_PLACES - 2)))
+            }
+
+            pub const fn new_permille(x: u128) -> Self {
+                Self($constructor(x * 10_u128.pow(Self::DECIMAL_PLACES - 3)))
+            }
+
+            pub const fn new_bps(x: u128) -> Self {
+                Self($constructor(x * 10_u128.pow(Self::DECIMAL_PLACES - 4)))
+            }
+        }
 
         // Ex: From<U256> for Udec256
         impl From<$inner> for $name {
@@ -688,17 +647,19 @@ macro_rules! generate_decimal {
 }
 
 generate_decimal! {
-    name           = Udec128,
-    inner_type     = u128,
-    from_dec       = [],
-    doc            = "128-bit unsigned fixed-point number with 18 decimal places.",
+    name              = Udec128,
+    inner_type        = u128,
+    inner_constructor = Uint128::new,
+    from_dec          = [],
+    doc               = "128-bit unsigned fixed-point number with 18 decimal places.",
 }
 
 generate_decimal! {
-    name           = Udec256,
-    inner_type     = U256,
-    from_dec       = [Udec128],
-    doc            = "256-bit unsigned fixed-point number with 18 decimal places.",
+    name              = Udec256,
+    inner_type        = U256,
+    inner_constructor = Uint256::new_from_u128,
+    from_dec          = [Udec128],
+    doc               = "256-bit unsigned fixed-point number with 18 decimal places.",
 }
 
 // ----------------------------------- tests -----------------------------------
@@ -706,7 +667,7 @@ generate_decimal! {
 #[cfg(test)]
 mod tests {
     use {
-        crate::{Number, Udec128, Udec256},
+        crate::{Number, NumberConst, Udec128, Udec256},
         bnum::{
             errors::TryFromIntError,
             types::{U256, U512},
@@ -716,7 +677,7 @@ mod tests {
 
     #[test]
     fn t1() {
-        assert_eq!(Udec128::one() + Udec128::one(), Udec128::new(2_u128));
+        assert_eq!(Udec128::ONE + Udec128::ONE, Udec128::new(2_u128));
 
         assert_eq!(
             Udec128::new(10_u128)

--- a/crates/storage/src/key.rs
+++ b/crates/storage/src/key.rs
@@ -360,7 +360,7 @@ where
     }
 }
 
-impl<T, const S: u32> PrimaryKey for Udec<T, S>
+impl<T> PrimaryKey for Udec<T>
 where
     Uint<T>: PrimaryKey<Output = Uint<T>>,
 {
@@ -592,7 +592,7 @@ where
     }
 }
 
-impl<T, const S: u32> Prefixer for Udec<T, S>
+impl<T> Prefixer for Udec<T>
 where
     Uint<T>: PrimaryKey<Output = Uint<T>>,
 {

--- a/crates/types/src/macros.rs
+++ b/crates/types/src/macros.rs
@@ -806,7 +806,7 @@ macro_rules! impl_number {
 
     // Udec Self
     (impl Udec with $imp:ident, $method:ident for $t:ty where sub fn $sub_method:ident) => {
-        impl<U, const S: u32> std::ops::$imp for $t
+        impl<U> std::ops::$imp for $t
         where
             Self: Number,
         {
@@ -869,7 +869,7 @@ macro_rules! impl_assign_number {
 
     // Udec
     (impl Udec with $imp:ident, $method:ident for $t:ty where sub fn $sub_method:ident) => {
-        impl<U, const S: u32> std::ops::$imp for $t
+        impl<U> std::ops::$imp for $t
         where
             Self: Number + Copy,
         {
@@ -992,7 +992,7 @@ macro_rules! forward_ref_binop_typed {
 #[doc(hidden)]
 macro_rules! forward_ref_binop_decimal {
     (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
-        impl<U, const S: u32> std::ops::$imp<$u> for &'_ $t
+        impl<U> std::ops::$imp<$u> for &'_ $t
         where
             $t: std::ops::$imp<$u> + Copy,
         {
@@ -1004,7 +1004,7 @@ macro_rules! forward_ref_binop_decimal {
             }
         }
 
-        impl<U, const S: u32> std::ops::$imp<&$u> for $t
+        impl<U> std::ops::$imp<&$u> for $t
         where
             $t: std::ops::$imp<$u> + Copy,
         {
@@ -1016,7 +1016,7 @@ macro_rules! forward_ref_binop_decimal {
             }
         }
 
-        impl<U, const S: u32> std::ops::$imp<&$u> for &'_ $t
+        impl<U> std::ops::$imp<&$u> for &'_ $t
         where
             $t: std::ops::$imp<$u> + Copy,
         {
@@ -1050,7 +1050,7 @@ macro_rules! forward_ref_op_assign_typed {
 #[doc(hidden)]
 macro_rules! forward_ref_op_assign_decimal {
     (impl $imp:ident, $method:ident for $t:ty, $u:ty) => {
-        impl<U, const S: u32> std::ops::$imp<&$u> for $t
+        impl<U> std::ops::$imp<&$u> for $t
         where
             $t: std::ops::$imp<$u> + Copy,
         {

--- a/docs/guides/math.md
+++ b/docs/guides/math.md
@@ -15,7 +15,7 @@ Grug provides a number of number types for use in smart contracts. They are buil
 | type                    | description                                     |
 | ----------------------- | ----------------------------------------------- |
 | `Uint<U>`               | unsigned integer                                |
-| `Udec<U, const S: u32>` | unsigned decimal                                |
+| `Udec<U>` | unsigned decimal                                |
 | `Signed<T>`             | wrapper over unsigned types to make them signed |
 
 It is, however, not recommended to use these types directly. Instead, Grug exports the following type alises:

--- a/docs/guides/math.md
+++ b/docs/guides/math.md
@@ -12,28 +12,28 @@ Rust's primitive number types are insufficient for smart contract use cases, for
 
 Grug provides a number of number types for use in smart contracts. They are built with the following three primitive types:
 
-| type                    | description                                     |
-| ----------------------- | ----------------------------------------------- |
-| `Uint<U>`               | unsigned integer                                |
-| `Udec<U>` | unsigned decimal                                |
-| `Signed<T>`             | wrapper over unsigned types to make them signed |
+| type        | description                                     |
+| ----------- | ----------------------------------------------- |
+| `Uint<U>`   | unsigned integer                                |
+| `Udec<U>`   | unsigned decimal                                |
+| `Signed<T>` | wrapper over unsigned types to make them signed |
 
 It is, however, not recommended to use these types directly. Instead, Grug exports the following type alises:
 
-| alias     | type                     | description                                                |
-| --------- | ------------------------ | ---------------------------------------------------------- |
-| `Uint64`  | `Uint<u64>`              | 64-bit unsigned integer                                    |
-| `Uint128` | `Uint<u128>`             | 128-bit unsigned integer                                   |
-| `Uint256` | `Uint<U256>`             | 256-bit unsigned integer                                   |
-| `Uint512` | `Uint<U512>`             | 512-bit unsigned integer                                   |
-| `Int64`   | `Signed<Uint<u64>>`      | 64-bit signed integer                                      |
-| `Int128`  | `Signed<Uint<u128>>`     | 128-bit signed integer                                     |
-| `Int256`  | `Signed<Uint<U256>>`     | 256-bit signed integer                                     |
-| `Int512`  | `Signed<Uint<U512>>`     | 512-bit signed integer                                     |
-| `Udec128` | `Udec<u128, 18>`         | 128-bit unsigned fixed-point number with 18 decimal places |
-| `Udec256` | `Udec<U256, 18>`         | 256-bit unsigned fixed-point number with 18 decimal places |
-| `Dec128`  | `Signed<Udec<u128, 18>>` | 128-bit signed fixed-point number with 18 decimal places   |
-| `Dec256`  | `Signed<Udec<U256, 18>>` | 256-bit signed fixed-point number with 18 decimal places   |
+| alias     | type                 | description                                                |
+| --------- | -------------------- | ---------------------------------------------------------- |
+| `Uint64`  | `Uint<u64>`          | 64-bit unsigned integer                                    |
+| `Uint128` | `Uint<u128>`         | 128-bit unsigned integer                                   |
+| `Uint256` | `Uint<U256>`         | 256-bit unsigned integer                                   |
+| `Uint512` | `Uint<U512>`         | 512-bit unsigned integer                                   |
+| `Int64`   | `Signed<Uint<u64>>`  | 64-bit signed integer                                      |
+| `Int128`  | `Signed<Uint<u128>>` | 128-bit signed integer                                     |
+| `Int256`  | `Signed<Uint<U256>>` | 256-bit signed integer                                     |
+| `Int512`  | `Signed<Uint<U512>>` | 512-bit signed integer                                     |
+| `Udec128` | `Udec<u128>`         | 128-bit unsigned fixed-point number with 18 decimal places |
+| `Udec256` | `Udec<U256>`         | 256-bit unsigned fixed-point number with 18 decimal places |
+| `Dec128`  | `Signed<Udec<u128>>` | 128-bit signed fixed-point number with 18 decimal places   |
+| `Dec256`  | `Signed<Udec<U256>>` | 256-bit signed fixed-point number with 18 decimal places   |
 
 where `U{256,512}` are from the [bnum][bnum] library.
 


### PR DESCRIPTION
Removed `const S: u32` as generic param for `Udec`, hardcoded to `18`